### PR TITLE
Explicitly raise an error when server returns http 403 and dont continue

### DIFF
--- a/lib/eventsource.js
+++ b/lib/eventsource.js
@@ -70,6 +70,11 @@ function EventSource(url) {
 
             if (res.statusCode == 204) return self.close();
 
+            if (res.statusCode == 403) {
+                _emit('error', 'Access denied');
+                return self.close();
+            }
+
             readyState = EventSource.OPEN;
             res.on('close', onConnectionClosed);
             res.on('end', onConnectionClosed);

--- a/test/eventsource_test.js
+++ b/test/eventsource_test.js
@@ -289,6 +289,24 @@ exports['HTTP Request'] = {
             });
     },
 
+    'http 403 causes error event': function(test) {
+        var headers;
+        var url = 'http://localhost:' + port;
+        createServer(["id: 1\ndata: hello world\n\n"],
+            function(close) {
+                var es = new EventSource(url);
+                es.onerror = function() {
+                    test.ok(true, 'got error');
+                    es.close();
+                    close(test.done);
+                };
+            },
+            function(req, res) {
+                res.writeHead(403, {'Content-Type': 'text/html'});
+                res.end();
+            });
+    },
+
     'http 301 with missing location causes error event': function(test) {
         var headers;
         var url = 'http://localhost:' + port;


### PR DESCRIPTION
Previously if the server returned a 403, eventsource would begin a retry
loop to connect to the server over and over. This loop will start before
a client can attach to the 'error' event because eventsource connects
right away in the constructor. This prevents client code from closing
the eventsource connection. This commit addresses this issue and fails
fast instead of allowing eventsource to enter a retry loop when a server
returns a 403.
