### PR TITLE
Fix Unicode support to cope with Javascript Unicode size limitations

### DIFF
--- a/lib/eventstream.jison
+++ b/lib/eventstream.jison
@@ -5,7 +5,12 @@
 \u0020					return 'space';
 ":"							return 'colon';
 (\u000D\u000A|\u000D|\u000A) return 'eol';
-[\u0000-\u0009\u000B-\u000C\u000E-\u0019\u0021-\u0039\u003B-\u10FFFF]	return 'char';
+
+/* Javascript can't support \u10FFFF , it's too large.
+\uFFFFF is only 1 less and works correctly, size limitations! */
+
+[\u0000-\u0009\u000B-\u000C\u000E-\u0019\u0021-\u0039\u003B-\uFFFFF]	return 'char';
+
 <<EOF>>					return 'EOF';
 .								return 'INVALID';
 

--- a/lib/eventstream.js
+++ b/lib/eventstream.js
@@ -9,11 +9,11 @@ performAction: function anonymous(yytext,yyleng,yylineno,yy,yystate,$$,_$) {
 
 var $0 = $$.length - 1;
 switch (yystate) {
-case 1: return this.$; 
+case 1: return this.$;
 break;
-case 2: this.$ = $$[$0-2]; this.$.push($$[$0-1]); 
+case 2: this.$ = $$[$0-2]; this.$.push($$[$0-1]);
 break;
-case 3: this.$ = [$$[$0-1]]; 
+case 3: this.$ = [$$[$0-1]];
 break;
 case 4:
 			this.$ = $$[$0-1];
@@ -22,7 +22,7 @@ case 4:
 	 		else if ($$[$0].name == 'event') this.$.event = $$[$0].value;
 	 		else if ($$[$0].name == 'id') this.$.id = $$[$0].value;
 	 		else if ($$[$0].name == 'retry') this.$.field = $$[$0].value;
-		
+
 break;
 case 5:
 	 		this.$ = {
@@ -34,21 +34,21 @@ case 5:
 	 		else if ($$[$0].name == 'event') this.$.event = $$[$0].value;
 	 		else if ($$[$0].name == 'id') this.$.id = $$[$0].value;
 	 		else if ($$[$0].name == 'retry') this.$.field = $$[$0].value;
-		
+
 break;
-case 8: this.$ = { name: 'comment', value: $$[$0] } 
+case 8: this.$ = { name: 'comment', value: $$[$0] }
 break;
-case 9: this.$ = { name: 'comment', value: '' } 
+case 9: this.$ = { name: 'comment', value: '' }
 break;
-case 10: this.$ = { name: $$[$0-3], value: $$[$0-1][0] === ' ' ? $$[$0-1].slice(1) : $$[$0-1] } 
+case 10: this.$ = { name: $$[$0-3], value: $$[$0-1][0] === ' ' ? $$[$0-1].slice(1) : $$[$0-1] }
 break;
-case 11: this.$ = { name: $$[$0-2], value: '' } 
+case 11: this.$ = { name: $$[$0-2], value: '' }
 break;
-case 12: this.$ = { name: $$[$0-1], value: '' } 
+case 12: this.$ = { name: $$[$0-1], value: '' }
 break;
-case 14: this.$ = $$[$0-1] + $$[$0]; 
+case 14: this.$ = $$[$0-1] + $$[$0];
 break;
-case 16: this.$ = $$[$0-1] + $$[$0]; 
+case 16: this.$ = $$[$0-1] + $$[$0];
 break;
 }
 },
@@ -350,7 +350,7 @@ case 6:return 'INVALID';
 break;
 }
 };
-lexer.rules = [/^(?:^\uFEFF)/,/^(?:\u0020)/,/^(?::)/,/^(?:(\u000D\u000A|\u000D|\u000A))/,/^(?:[\u0000-\u0009\u000B-\u000C\u000E-\u0019\u0021-\u0039\u003B-\u10FFFF])/,/^(?:$)/,/^(?:.)/];
+lexer.rules = [/^(?:^\uFEFF)/,/^(?:\u0020)/,/^(?::)/,/^(?:(\u000D\u000A|\u000D|\u000A))/,/^(?:[\u0000-\u0009\u000B-\u000C\u000E-\u0019\u0021-\u0039\u003B-\uFFFFF])/,/^(?:$)/,/^(?:.)/];
 lexer.conditions = {"INITIAL":{"rules":[0,1,2,3,4,5,6],"inclusive":true}};
 return lexer;})()
 parser.lexer = lexer;

--- a/test/eventsource_test.js
+++ b/test/eventsource_test.js
@@ -42,6 +42,17 @@ exports['Messages'] = {
         done();
     },
 
+    'Multibyte Characters': function(test) {
+        createServer(["id: 1\ndata: €豆腐\n\n"], function(close) {
+            var es = new EventSource('http://localhost:' + port);
+            es.onmessage = function(m) {
+                test.equal("€豆腐", m.data);
+                es.close();
+                close(test.done);
+            };
+        });
+    },
+
     'issue-18': function(test) {
         createServer(["id: 1\ndata: hello world\n\n"], function(close) {
             var es = new EventSource('http://localhost:' + port);


### PR DESCRIPTION
Looks like jison was parsing incorrectly due to a size limitation with javascript unicode support

Test data:

```
id: 1
data: hello world

event: test
data: {"body":"豆腐"}


```

Python:

``` python
0x8C46 in range(0x003B,0x10FFFF)
True
```

Jison:

``` js
[\u003B-\u10FFFF] return 'char';

Parse error on line 5:
...testdata: {"body":"豆腐"}
----------------------^
Expecting 'eol', 'colon', 'char', 'space', got 'INVALID'
```

Python:

``` python
0x8C46 in range(0x003B,0x9FFFF)
True
```

Jison

``` js
[\u003B-\u9FFFF] return 'char';

[{"comments":[],"data":"hello world\n","id":"1"},{"comments":[],"data":"{\"body\":\"豆腐\"}\n","event":"test"}]
```

it also happens in both chrome and firefox's js consoles:

``` js
"豆".match(/[0-\u10FFFF]/)
null

"豆".match(/[0-\uFFFFF]/)
["豆"]

"豆".match(/[0-\u9FFFF]/)
["豆"]
```

Even a single decimal character less ( 10 -> F , 16 to 15 ) makes it work with no discernible impact on actual usability ( It's a single character at the very tip top of Supplemental Private Use Area-B )
