### PR TITLE
Newlines stripped from head of buffer

### DIFF
--- a/lib/eventsource.js
+++ b/lib/eventsource.js
@@ -110,9 +110,13 @@ function EventSource(url, eventSourceInitDict) {
                 buf = buf + chunk;
                 var messages = buf.match(/(.|\r\n|\n|\r)*(\n\n|\r\r|\r\n\r\n)/);
                 if (!messages) return;
-                // Grab the matched message and remove any newline prefix.
-                messages = messages[0].replace(/^(\n)*/, '');
+                // Grab the messages (match returns an array).
+                messages = messages[0];
+                // Cut the buffer.
                 buf = buf.slice(messages.length);
+                // Strip any newline prefix (which may have accumulated from
+                // heartbeat signals and would cause a parse error).
+                messages = messages.replace(/^(\n)*/, '');
                 try {
                   messages = eventstream.parse(messages);
                   if (!messages) return;


### PR DESCRIPTION
In my application, eventsource is used with CouchDB's _changes stream.
CouchDB sends a heartbeat message, which is just a newline. This is appended
to the buffer string (buf) and if the buffer string is empty, then the first
regexp `/(.|\r\n|\n|\r)*(\n\n|\r\r|\r\n\r\n)/` will not match it, and messages
will be falsy; no action is taken, and buf is `'\n'`.

Suppose now that CouchDB responds with some real data, rather than a heartbeat.
We add this real data to the buffer, and the regexp returns a match! However,
that match is prefixed with a newline, so the eventstream parser fails and the
data is lost.

This bug was rather elusive, because if another heartbeat would come,
then we'd have `buf == '\n\n'` and this would match the first regexp! The
buffer is reset, and the next message is processed normally (assuming it
comes before the next heartbeat).
