### PR TITLE
Fixes #30 Provide Event on open and error event

### DIFF
--- a/lib/eventsource.js
+++ b/lib/eventsource.js
@@ -37,7 +37,7 @@ function EventSource(url, eventSourceInitDict) {
         if (connectPending || readyState === EventSource.CLOSED) return;
         connectPending = true;
         readyState = EventSource.CONNECTING;
-        _emit('error', err);
+        _emit('error', new Event('error'));
 
         // The url may have been changed by a temporary
         // redirect. If that's the case, revert it now.
@@ -84,7 +84,8 @@ function EventSource(url, eventSourceInitDict) {
             // Handle HTTP redirects
             if (res.statusCode == 301 || res.statusCode == 307) {
                 if (!res.headers.location) {
-                    _emit('error', 'Server sent redirect response without Location header.');
+                	// Server sent redirect response without Location header.
+                    _emit('error', new Event('error'));
                     return;
                 }
                 if (res.statusCode == 307) reconnectUrl = url;
@@ -96,14 +97,15 @@ function EventSource(url, eventSourceInitDict) {
             if (res.statusCode == 204) return self.close();
 
             if (res.statusCode == 403) {
-                _emit('error', 'Access denied');
+            	// 'Access denied'
+                _emit('error', new Event('error'));
                 return self.close();
             }
 
             readyState = EventSource.OPEN;
             res.on('close', onConnectionClosed);
             res.on('end', onConnectionClosed);
-            _emit('open');
+            _emit('open', new Event('open'));
 
             var buf = '';
             res.on('data', function (chunk) {
@@ -124,7 +126,7 @@ function EventSource(url, eventSourceInitDict) {
                       _emit(message.event || 'message', new MessageEvent(data));
                   });
                 } catch(e) {
-                  _emit('error', e);
+                  _emit('error', new Event('error'));
                 }
             });
         });
@@ -204,6 +206,16 @@ EventSource.prototype.addEventListener = function addEventListener(method, liste
         this.on(method, listener);
     }
 };
+
+/**
+ * W3C Event
+ *
+ * @see http://www.w3.org/TR/DOM-Level-3-Events/#interface-Event
+ * @api private
+ */
+function Event(type) {
+    Object.defineProperty(this, 'type', { writable: false, value: type });
+}
 
 /**
  * W3C MessageEvent

--- a/test/eventsource_test.js
+++ b/test/eventsource_test.js
@@ -785,7 +785,8 @@ describe('Events', function() {
     it('calls onopen when connection is established', function(done) {
         createServer([], function(port, close) {
             var es = new EventSource('http://localhost:' + port);
-            es.onopen = function() {
+            es.onopen = function(event) {
+                assert.equal(event.type, 'open');
                 es.close();
                 close(done);
             }
@@ -795,7 +796,8 @@ describe('Events', function() {
     it('emits open event when connection is established', function(done) {
         createServer([], function(port, close) {
             var es = new EventSource('http://localhost:' + port);
-            es.addEventListener('open', function() {
+            es.addEventListener('open', function(event) {
+                assert.equal(event.type, 'open');
                 es.close();
                 close(done);
             });


### PR DESCRIPTION
This pull request provides simple event having only type property for open and error event. I thought to implement Event interface but it requires so many additional things or dependency on something like jsdom to call 'document.createEvent'.

So I fixed it by creating an Event object like MessageEvent. Also, since the error event is only just Event having no property explaining the close reason, I commented them.

Let me know how you think.
