### PR TITLE
Fix message type

### DIFF
--- a/lib/eventsource.js
+++ b/lib/eventsource.js
@@ -182,7 +182,7 @@ function EventSource(url, eventSourceInitDict) {
     if (lineLength === 0) {
       if (data.length > 0) {
         var type = eventName || 'message';
-        _emit(type, new MessageEvent('message', {
+        _emit(type, new MessageEvent(type, {
           data: data.slice(0, -1), // remove trailing newline
           lastEventId: lastEventId
         }));


### PR DESCRIPTION
When creating a `MessageEvent`, the current type is not given but `"message"` is always used instead.
This pull request fix this.
