### PR TITLE
[fix] Added missing origin property.

### DIFF
--- a/lib/eventsource.js
+++ b/lib/eventsource.js
@@ -1,7 +1,9 @@
-var http = require('http')
+var original = require('original')
+  , parse = require('url').parse
+  , events = require('events')
   , https = require('https')
-  , util = require('util')
-  , events = require('events');
+  , http = require('http')
+  , util = require('util');
 
 function isPlainObject(obj) {
   return Object.getPrototypeOf(obj) === Object.prototype;
@@ -68,7 +70,7 @@ function EventSource(url, eventSourceInitDict) {
   function connect() {
     connectPending = false;
 
-    var options = require('url').parse(url);
+    var options = parse(url);
     var isSecure = options.protocol == 'https:';
     options.headers = { 'Cache-Control': 'no-cache', 'Accept': 'text/event-stream' };
     if (lastEventId) options.headers['Last-Event-ID'] = lastEventId;
@@ -184,7 +186,8 @@ function EventSource(url, eventSourceInitDict) {
         var type = eventName || 'message';
         _emit(type, new MessageEvent(type, {
           data: data.slice(0, -1), // remove trailing newline
-          lastEventId: lastEventId
+          lastEventId: lastEventId,
+          origin: original(url)
         }));
         data = '';
       }

--- a/package.json
+++ b/package.json
@@ -48,5 +48,8 @@
   },
   "engines": {
     "node": ">=0.6.0"
+  },
+  "dependencies": {
+    "original": "0.0.x"
   }
 }

--- a/test/eventsource_test.js
+++ b/test/eventsource_test.js
@@ -830,6 +830,17 @@ describe('Events', function () {
     });
   });
 
+  it('supplies the correct origin', function (done) {
+    createServer(["id: 123\ndata: sample_data\n\n"], function (port, close) {
+      var es = new EventSource('http://localhost:' + port);
+      es.onmessage = function (event) {
+        assert.equal(event.origin, 'http://localhost:'+ port);
+        es.close();
+        close(done);
+      }
+    });
+  });
+
   it('emits open event when connection is established', function (done) {
     createServer([], function (port, close) {
       var es = new EventSource('http://localhost:' + port);


### PR DESCRIPTION
Fixes #38

Also moved the `require(url).parse` out of the construction phase. It's a pointless performance hit and the require should be cached. 
