### PR TITLE
Emit `error` event when calling `EventSource.close()`

### DIFF
--- a/lib/eventsource.js
+++ b/lib/eventsource.js
@@ -187,6 +187,7 @@ function EventSource(url, eventSourceInitDict) {
     readyState = EventSource.CLOSED;
     if (req.abort) req.abort();
     if (req.xhr && req.xhr.abort) req.xhr.abort();
+    _emit('error', new Event('error'));
   };
 
   function parseEventStreamLine(buf, pos, fieldLength, lineLength) {

--- a/test/eventsource_test.js
+++ b/test/eventsource_test.js
@@ -462,6 +462,8 @@ describe('HTTP Request', function () {
 
         var es = new EventSource(server.url);
         es.onerror = function (err) {
+          if(this.readyState === EventSource.CLOSED) return
+
           assert.equal(err.status, status);
           server.close(done);
         };
@@ -588,6 +590,8 @@ describe('Reconnection', function () {
       es.reconnectInterval = 0;
 
       es.onerror = function (e) {
+        if(this.readyState === EventSource.CLOSED) return
+
         assert.equal(e.status, 204);
         server.close(function (err) {
           if(err) return done(err);
@@ -695,6 +699,8 @@ describe('readyState', function () {
     var es = new EventSource('http://localhost:' + _port);
     assert.equal(EventSource.CONNECTING, es.readyState);
     es.onerror = function () {
+      if(this.readyState === EventSource.CLOSED) return
+
       es.close();
       done();
     }
@@ -813,10 +819,12 @@ describe('Events', function () {
       es.addEventListener('open', function () {
         es.close();
         process.nextTick(function () {
-          server.close(done);
+          server.close();
         });
       });
       es.addEventListener('error', function () {
+        if(this.readyState === EventSource.CLOSED) return done()
+
         done(new Error('error should not be emitted'));
       });
     });


### PR DESCRIPTION
The spec [says](https://html.spec.whatwg.org/multipage/comms.html#fail-the-connection):

> When a user agent is to fail the connection, the user agent must queue a task which, if the readyState attribute is set to a value other than CLOSED, sets the readyState attribute to CLOSED and fires a simple event named error at the EventSource object. Once the user agent has failed the connection, it does not attempt to reconnect!

This pull-request makes that `error` event to be emitted. I needed to update the tests because when an error ocurred the `error` event was dispatched multiple times (one for the error, and one to notify the clossing). The _Reconnection is stopped when server goes down and eventsource is being closed_ test is not passing due to a `EADDRINUSE` that I can't be able to identify, but the other ones works correctly.
