### PR TITLE
Double Reconnect Test

### DIFF
--- a/lib/eventsource.js
+++ b/lib/eventsource.js
@@ -112,11 +112,7 @@ function EventSource(url, eventSourceInitDict) {
         if (res.statusCode == 204) return self.close();
         return
       }
-      // protect against multiple connects
-      if (readyState === EventSource.OPEN) {
-          return;
-      }
-      
+
       readyState = EventSource.OPEN;
       res.on('close', onConnectionClosed);
       res.on('end', onConnectionClosed);

--- a/lib/eventsource.js
+++ b/lib/eventsource.js
@@ -112,7 +112,11 @@ function EventSource(url, eventSourceInitDict) {
         if (res.statusCode == 204) return self.close();
         return
       }
-
+      // protect against multiple connects
+      if (readyState === EventSource.OPEN) {
+          return;
+      }
+      
       readyState = EventSource.OPEN;
       res.on('close', onConnectionClosed);
       res.on('end', onConnectionClosed);

--- a/lib/eventsource.js
+++ b/lib/eventsource.js
@@ -117,13 +117,13 @@ function EventSource(url, eventSourceInitDict) {
       res.on('close', function() {
         res.removeAllListeners('close');
         res.removeAllListeners('end');
-        onConnectionClosed()
+        onConnectionClosed();
       });
 
       res.on('end', function() {
         res.removeAllListeners('close');
         res.removeAllListeners('end');
-        onConnectionClosed()
+        onConnectionClosed();
       });
       _emit('open', new Event('open'));
 

--- a/lib/eventsource.js
+++ b/lib/eventsource.js
@@ -114,8 +114,17 @@ function EventSource(url, eventSourceInitDict) {
       }
 
       readyState = EventSource.OPEN;
-      res.on('close', onConnectionClosed);
-      res.on('end', onConnectionClosed);
+      res.on('close', function() {
+        res.removeAllListeners('close');
+        res.removeAllListeners('end');
+        onConnectionClosed()
+      });
+
+      res.on('end', function() {
+        res.removeAllListeners('close');
+        res.removeAllListeners('end');
+        onConnectionClosed()
+      });
       _emit('open', new Event('open'));
 
       // text/event-stream parser adapted from webkit's


### PR DESCRIPTION
Here's a PR with both @philstrong work and my test to expose the bug.

The test's approach is for the server to disconnect the first connection immediately.  Subsequent connections are allowed to sit around.  You would expect 2 connections (1 initial, 1 retry) within the timeframe of the test, however there are actually 3 that are made (2 retries).

The test might not be to your liking as it waits 1500 seconds before succeeding.  This threshold basically has to exceed the 1,000 of the `reconnectInterval` so that the client may issue a 2nd (and 3rd) reconnect.
