### PR TITLE
Remove unneeded isPlainObject function

### DIFF
--- a/lib/eventsource.js
+++ b/lib/eventsource.js
@@ -5,10 +5,6 @@ var original = require('original')
   , http = require('http')
   , util = require('util');
 
-function isPlainObject(obj) {
-  return Object.getPrototypeOf(obj) === Object.prototype;
-}
-
 /**
  * Creates a new EventSource object
  *
@@ -54,7 +50,7 @@ function EventSource(url, eventSourceInitDict) {
 
   var req;
   var lastEventId = '';
-  if (eventSourceInitDict && eventSourceInitDict.headers && isPlainObject(eventSourceInitDict.headers) && eventSourceInitDict.headers['Last-Event-ID']) {
+  if (eventSourceInitDict && eventSourceInitDict.headers && eventSourceInitDict.headers['Last-Event-ID']) {
     lastEventId = eventSourceInitDict.headers['Last-Event-ID'];
     delete eventSourceInitDict.headers['Last-Event-ID'];
   }
@@ -71,7 +67,7 @@ function EventSource(url, eventSourceInitDict) {
     var isSecure = options.protocol == 'https:';
     options.headers = { 'Cache-Control': 'no-cache', 'Accept': 'text/event-stream' };
     if (lastEventId) options.headers['Last-Event-ID'] = lastEventId;
-    if (eventSourceInitDict && eventSourceInitDict.headers && isPlainObject(eventSourceInitDict.headers)) {
+    if (eventSourceInitDict && eventSourceInitDict.headers) {
       for (var i in eventSourceInitDict.headers) {
         var header = eventSourceInitDict.headers[i];
         if (header) {


### PR DESCRIPTION
It's the function caller's responsibility to pass the expected argument type. If they pass something "truthy" that is not an Object object, then the behavior of the function is undefined. We shouldn't work around such mistakes by the caller. What did they mean to pass for the argument? And why should we care if the Object object is of the "plain" variety?

This pull request is just a half step in the right direction. A better solution would be to throw an exception on receiving incorrect arguments.