### PR TITLE
Added no-store

### DIFF
--- a/lib/eventsource.js
+++ b/lib/eventsource.js
@@ -69,7 +69,7 @@ function EventSource(url, eventSourceInitDict) {
 
     var options = parse(url);
     var isSecure = options.protocol == 'https:';
-    options.headers = { 'Cache-Control': 'no-cache', 'Accept': 'text/event-stream' };
+    options.headers = { 'Cache-Control': 'no-cache, no-store', 'Accept': 'text/event-stream' };
     if (lastEventId) options.headers['Last-Event-ID'] = lastEventId;
     if (eventSourceInitDict && eventSourceInitDict.headers && isPlainObject(eventSourceInitDict.headers)) {
       for (var i in eventSourceInitDict.headers) {


### PR DESCRIPTION
If you serve multiple content types from the same URL, you want to add `no-store` or Chrome can stall.  See http://stackoverflow.com/questions/27513994/chrome-stalls-when-making-multiple-requests-to-same-resource

I've experienced this first hand.  It is hard to diagnose, so it would be best to spare users the misery of diagnosing this themselves.