### PR TITLE
Eventsource 50x support

### DIFF
--- a/lib/eventsource.js
+++ b/lib/eventsource.js
@@ -110,6 +110,13 @@ function EventSource (url, eventSourceInitDict) {
     }
 
     req = (isSecure ? https : http).request(options, function (res) {
+      // Handle HTTP errors
+      if (res.statusCode === 500 || res.statusCode === 502 || res.statusCode === 503 || res.statusCode === 504) {
+        _emit('error', new Event('error', {status: res.statusCode}))
+        onConnectionClosed()
+        return
+      }
+
       // Handle HTTP redirects
       if (res.statusCode === 301 || res.statusCode === 307) {
         if (!res.headers.location) {

--- a/test/eventsource_test.js
+++ b/test/eventsource_test.js
@@ -607,13 +607,17 @@ describe('Reconnection', function () {
 
       server.on('request', function (req, res) {
         res.writeHead(500)
-        res.end();
+        res.end()
       })
 
-      var es = new EventSource(server.url);
-      es.reconnectInterval = 0;
+      var es = new EventSource(server.url)
+      es.reconnectInterval = 0
+
+      var errored = false
 
       es.onerror = function () {
+        if (errored) return
+        errored = true
         server.close(function (err) {
           if (err) return done(err)
 


### PR DESCRIPTION
Based on the [processing model](https://www.w3.org/TR/2015/REC-eventsource-20150203/#processing-model),

![image](https://cloud.githubusercontent.com/assets/2464813/25887623/6eb3797e-3595-11e7-93a0-7f55d985a66f.png)

In Google Chrome this is implemented correctly:
1. EventSource instance connects to the server.
2. Server breaks the connection.
3. Because it's a back-end behind nginx, now it returns a 502 error code.
4. After some time, the HTTP service returns to normal and begins serving content (and 200 status codes) again.
5. EventSource instance continues receiving messages.
