### PR TITLE
Make `close()` a prototype method. Closes #67.

### DIFF
--- a/lib/eventsource.js
+++ b/lib/eventsource.js
@@ -214,7 +214,7 @@ function EventSource (url, eventSourceInitDict) {
     }
   }
 
-  this.close = function () {
+  this._close = function () {
     if (readyState === EventSource.CLOSED) return
     readyState = EventSource.CLOSED
     if (req.abort) req.abort()
@@ -308,6 +308,16 @@ Object.defineProperty(EventSource, 'CLOSED', {enumerable: true, value: 2})
 EventSource.prototype.CONNECTING = 0
 EventSource.prototype.OPEN = 1
 EventSource.prototype.CLOSED = 2
+
+/**
+ * Closes the connection, if one is made, and sets the readyState attribute to 2 (closed)
+ *
+ * @see https://developer.mozilla.org/en-US/docs/Web/API/EventSource/close
+ * @api public
+ */
+EventSource.prototype.close = function () {
+  this._close()
+}
 
 /**
  * Emulates the W3C Browser based WebSocket interface using addEventListener.

--- a/test/eventsource_test.js
+++ b/test/eventsource_test.js
@@ -872,6 +872,24 @@ describe('readyState', function () {
   })
 })
 
+describe('Methods', function () {
+  it('close method exists and can be called to close an eventsource', function (done) {
+    createServer(function (err, server) {
+      if (err) return done(err)
+      var es = new EventSource(server.url)
+      server.on('request', writeEvents([]))
+      es.onopen = function () {
+        assert.equal(es.close(), undefined)
+        server.close(done)
+      }
+    })
+  })
+
+  it('close method is a prototype method', function () {
+    assert.equal(typeof EventSource.prototype.close, 'function')
+  })
+})
+
 describe('Properties', function () {
   it('url exposes original request url', function () {
     var url = 'http://localhost:' + _port


### PR DESCRIPTION
This PR moves the `close()` method to the EventSource prototype, in order to align with the browser implementation and allow overriding it when subclassing.
