### PR TITLE
Fix error handling

### DIFF
--- a/lib/eventsource.js
+++ b/lib/eventsource.js
@@ -37,7 +37,7 @@ function EventSource (url, eventSourceInitDict) {
   function onConnectionClosed (error) {
     if (readyState === EventSource.CLOSED) return
     readyState = EventSource.CONNECTING
-    
+
     if (error) {
       _emit('error', new Event('error', error))
     }

--- a/lib/eventsource.js
+++ b/lib/eventsource.js
@@ -34,10 +34,13 @@ function EventSource (url, eventSourceInitDict) {
   var self = this
   self.reconnectInterval = 1000
 
-  function onConnectionClosed () {
+  function onConnectionClosed (error) {
     if (readyState === EventSource.CLOSED) return
     readyState = EventSource.CONNECTING
-    _emit('error', new Event('error'))
+    
+    if (error) {
+      _emit('error', new Event('error', error))
+    }
 
     // The url may have been changed by a temporary
     // redirect. If that's the case, revert it now.


### PR DESCRIPTION
Don't emit an `error` event if there is no error.

That has caused me some headaches lately when working with the [stellar sdk](https://github.com/stellar/js-stellar-sdk). I think that fix is rather critical.

Maybe you guys have a good idea for a regression test?