### PR TITLE
bump to 1.0.6

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,4 +1,4 @@
-# Unreleased
+# [1.0.6](https://github.com/EventSource/eventsource/compare/v1.0.6...v1.0.6)
 
 * Change example to use `eventsource/ssestream`
 

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,4 +1,4 @@
-# [1.0.6](https://github.com/EventSource/eventsource/compare/v1.0.6...v1.0.6)
+# [1.0.6](https://github.com/EventSource/eventsource/compare/v1.0.5...v1.0.6)
 
 * Change example to use `eventsource/ssestream`
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eventsource",
-  "version": "1.0.5",
+  "version": "1.0.6",
   "description": "W3C compliant EventSource client for Node.js and browser (polyfill)",
   "keywords": [
     "eventsource",


### PR DESCRIPTION
https://github.com/EventSource/eventsource/issues/97

I would like to bump the version to 1.0.6 so that it has the latest changes of ssestream.