### PR TITLE
Add dispatchEvent to EventSource

### DIFF
--- a/lib/eventsource.js
+++ b/lib/eventsource.js
@@ -346,6 +346,22 @@ EventSource.prototype.addEventListener = function addEventListener (type, listen
 }
 
 /**
+ * Emulates the W3C Browser based WebSocket interface using dispatchEvent.
+ *
+ * @param {Event} event An event to be dispatched
+ * @see https://developer.mozilla.org/en-US/docs/Web/API/EventTarget/dispatchEvent
+ * @api public
+ */
+EventSource.prototype.dispatchEvent = function dispatchEvent (event) {
+  if (!event.type) {
+    throw new Error('UNSPECIFIED_EVENT_TYPE_ERR')
+  }
+  // if event is instance of an CustomEvent (or has 'details' property),
+  // send the detail object as the payload for the event
+  this.emit(event.type, event.detail)
+}
+
+/**
  * Emulates the W3C Browser based WebSocket interface using removeEventListener.
  *
  * @param {String} type A string representing the event type to remove

--- a/test/eventsource_test.js
+++ b/test/eventsource_test.js
@@ -1079,6 +1079,50 @@ describe('Events', function () {
       }
     })
   })
+
+  it('throws error if the message type is unspecified, \'\' or null', function (done) {
+    createServer(function (err, server) {
+      if (err) return done(err)
+
+      var es = new EventSource(server.url)
+
+      assert.throws(function () { es.dispatchEvent({}) })
+      assert.throws(function () { es.dispatchEvent({type: undefined}) })
+      assert.throws(function () { es.dispatchEvent({type: ''}) })
+      assert.throws(function () { es.dispatchEvent({type: null}) })
+
+      server.close(done)
+    })
+  })
+
+  it('delivers the dispatched event without payload', function (done) {
+    createServer(function (err, server) {
+      if (err) return done(err)
+
+      var es = new EventSource(server.url)
+
+      es.addEventListener('greeting', function (m) {
+        server.close(done)
+      })
+
+      es.dispatchEvent({type: 'greeting'})
+    })
+  })
+
+  it('delivers the dispatched event with payload', function (done) {
+    createServer(function (err, server) {
+      if (err) return done(err)
+
+      var es = new EventSource(server.url)
+
+      es.addEventListener('greeting', function (m) {
+        assert.equal('Hello', m.data)
+        server.close(done)
+      })
+
+      es.dispatchEvent({type: 'greeting', detail: {data: 'Hello'}})
+    })
+  })
 })
 
 describe('Proxying', function () {


### PR DESCRIPTION
Adds `dispatchEvent` method to EventSource to make it compatible with the `EventSource` definition form https://developer.mozilla.org/en-US/docs/Web/API/EventSource.

`EventSource` extends `EventTarget` that has the `dispatchEvent` method:
https://developer.mozilla.org/en-US/docs/Web/API/EventTarget/dispatchEvent

The `Event` and `CustomEvent` objects are only available in DOM, so I tried to simulate them by `{ type: string}` and `{type: string, detail: object}` object literals:

https://developer.mozilla.org/en-US/docs/Web/Guide/Events/Creating_and_triggering_events