### PR TITLE
added checkServerIdentity option

### DIFF
--- a/lib/eventsource.js
+++ b/lib/eventsource.js
@@ -7,7 +7,7 @@ var util = require('util')
 
 var httpsOptions = [
   'pfx', 'key', 'passphrase', 'cert', 'ca', 'ciphers',
-  'rejectUnauthorized', 'secureProtocol', 'servername'
+  'rejectUnauthorized', 'secureProtocol', 'servername', 'checkServerIdentity'
 ]
 
 /**


### PR DESCRIPTION
added checkServerIdentity option to the list of allowed options

I request that you reconsider reopening case #71 
There are many https options that are configurable.  Limiting the https options also limits what can be configured at the tls layer
