### PR TITLE
Update dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,15 +31,15 @@
   ],
   "devDependencies": {
     "express": "^4.15.3",
-    "mocha": "^3.5.3",
-    "nyc": "^11.2.1",
+    "mocha": "^4.1.0",
+    "nyc": "^12.0.2",
     "serve-static": "^1.12.3",
     "ssestream": "^1.0.0",
-    "standard": "^10.0.2",
-    "webpack": "^3.5.6"
+    "standard": "^11.0.1",
+    "webpack": "^4.16.5"
   },
   "scripts": {
-    "test": "mocha --reporter spec && standard",
+    "test": "mocha --reporter spec --exit && standard",
     "polyfill": "webpack lib/eventsource-polyfill.js example/eventsource-polyfill.js",
     "postpublish": "git push && git push --tags",
     "coverage": "nyc --reporter=html --reporter=text _mocha --reporter spec"
@@ -48,7 +48,7 @@
     "node": ">=0.12.0"
   },
   "dependencies": {
-    "original": "^1.0.0"
+    "original": "^1.0.2"
   },
   "standard": {
     "ignore": [

--- a/test/eventsource_test.js
+++ b/test/eventsource_test.js
@@ -1058,7 +1058,7 @@ describe('Events', function () {
 
       function second (m) {
         assert.equal(m.data, 'World')
-        assert.equal(m.lastEventId, '123')  // expect to get back the previous event id
+        assert.equal(m.lastEventId, '123') // expect to get back the previous event id
         server.close(done)
       }
     })


### PR DESCRIPTION
Fixes #105 

I was unable to get mocha@5.2 to pass tests so I updated it to mocha@4.1 for now. Other minor changes were required to pass tests.