### PR TITLE
allow setting of HTTP request method and body

### DIFF
--- a/lib/eventsource.js
+++ b/lib/eventsource.js
@@ -130,6 +130,10 @@ function EventSource (url, eventSourceInitDict) {
       options.withCredentials = eventSourceInitDict.withCredentials
     }
 
+    if (eventSourceInitDict && eventSourceInitDict.method) {
+      options.method = eventSourceInitDict.method
+    }
+
     req = (isSecure ? https : http).request(options, function (res) {
       // Handle HTTP errors
       if (res.statusCode === 500 || res.statusCode === 502 || res.statusCode === 503 || res.statusCode === 504) {
@@ -226,6 +230,10 @@ function EventSource (url, eventSourceInitDict) {
         }
       })
     })
+
+    if (eventSourceInitDict && eventSourceInitDict.body) {
+      req.write(eventSourceInitDict.body)
+    }
 
     req.on('error', function (err) {
       onConnectionClosed(err.message)

--- a/test/eventsource_test.js
+++ b/test/eventsource_test.js
@@ -527,6 +527,42 @@ describe('HTTP Request', function () {
         }
       )
     })
+  })
+
+  it('uses GET method by default', function (done) {
+    createServer(function (err, server) {
+      if (err) return done(err)
+
+      server.on('request', function (req) {
+        assert.equal(req.method, 'GET')
+        server.close(done)
+      })
+
+      new EventSource(server.url)
+    })
+  })
+
+  it('can specify HTTP method and body', function (done) {
+    var content = '{ "test": true }'
+
+    createServer(function (err, server) {
+      if (err) return done(err)
+
+      server.on('request', function (req) {
+        assert.equal(req.method, 'POST')
+
+        var receivedContent = ''
+        req.on('data', function (chunk) {
+          receivedContent += chunk
+        })
+        req.on('end', function () {
+          assert.equal(content, receivedContent)
+          server.close(done)
+        })
+      })
+
+      new EventSource(server.url, { method: 'POST', body: content })
+    })
   });
 
   [301, 307].forEach(function (status) {


### PR DESCRIPTION
Browser implementations of EventSource only support GET requests; this allows you to use another method with a request body, such as POST or REPORT. This is not part of the SSE spec, but it's not contrary to it either, as the spec only describes how to process the response.

This is a somewhat unusual requirement of our application, but it's possible that it'll be useful to others as well.