### PR TITLE
Multiple sequential errors cause multiple reconnection attempts

### DIFF
--- a/lib/eventsource.js
+++ b/lib/eventsource.js
@@ -45,6 +45,7 @@ function EventSource (url, eventSourceInitDict) {
 
   var self = this
   self.reconnectInterval = 1000
+  self.connectionInProgress = false
 
   function onConnectionClosed (message) {
     if (readyState === EventSource.CLOSED) return
@@ -58,9 +59,10 @@ function EventSource (url, eventSourceInitDict) {
       reconnectUrl = null
     }
     setTimeout(function () {
-      if (readyState !== EventSource.CONNECTING) {
+      if (readyState !== EventSource.CONNECTING || self.connectionInProgress) {
         return
       }
+      self.connectionInProgress = true
       connect()
     }, self.reconnectInterval)
   }
@@ -131,6 +133,7 @@ function EventSource (url, eventSourceInitDict) {
     }
 
     req = (isSecure ? https : http).request(options, function (res) {
+      self.connectionInProgress = false
       // Handle HTTP errors
       if (res.statusCode === 500 || res.statusCode === 502 || res.statusCode === 503 || res.statusCode === 504) {
         _emit('error', new Event('error', {status: res.statusCode, message: res.statusMessage}))

--- a/test/eventsource_test.js
+++ b/test/eventsource_test.js
@@ -885,7 +885,7 @@ describe('Reconnection', function () {
           var fn = writeEvents(events)
           fn(req, res)
           eventsSent++
-          // now cause a parse error!
+          // now cause a few errors
           fn(req, res)
           eventsSent++
         } else {
@@ -899,7 +899,6 @@ describe('Reconnection', function () {
       assert.equal(EventSource.CONNECTING, es.readyState)
       es.reconnectInterval = 0
       es.onerror = function (err) {
-        console.log(err);
         errorOccurred = !!(errorOccurred || err)
       }
     })


### PR DESCRIPTION
I was seeing some weird behavior with a spotty server connection. 

When the server caused some sort of parse error or network exchange error, the EventSource client would attempt to reconnect to the server (via `onConnectionClosed`). 
The problem was that in between recognizing the network error, and actually reconnecting, there was a chance for another error to also force a reconection attempt. This would result in a new connection attempted for each error in that window. Thus 1 connection to the server with 2 errors would result in 2 new connections to the server. (see images below)
![Network error](https://user-images.githubusercontent.com/1545395/60136738-3dbe9480-9762-11e9-9ced-b2f9f8c21c32.png)
![Duplicating Requests](https://user-images.githubusercontent.com/1545395/60136736-3dbe9480-9762-11e9-91f8-6bdc192748e0.png)

Repeat this a few times and you get a compounding problem:
![More network errors](https://user-images.githubusercontent.com/1545395/60136737-3dbe9480-9762-11e9-800a-0f95a6f2fb9c.png)
![Duplicating Multiple Requests](https://user-images.githubusercontent.com/1545395/60136735-3d25fe00-9762-11e9-9fb0-06ac9fbf5ee5.png)

At some point in this process the server began interfering with the error states meaning some connections were kept open without an error, but others would continue to proliferate double connections
![SSE received preventing network error](https://user-images.githubusercontent.com/1545395/60136734-3d25fe00-9762-11e9-9469-e9c08f1e5320.png)

I expected to only see a single re-connection after each error. After the fix this is the behavior.
![After Fix](https://user-images.githubusercontent.com/1545395/60136739-3dbe9480-9762-11e9-9dbc-b5aaa1365f13.png)