### PR TITLE
Improve performance for large messages across many chunks

### DIFF
--- a/lib/eventsource.js
+++ b/lib/eventsource.js
@@ -174,6 +174,8 @@ function EventSource (url, eventSourceInitDict) {
       // Source/WebCore/page/EventSource.cpp
       var isFirst = true
       var buf
+      var startingPos = 0
+      var startingFieldLength = -1
       res.on('data', function (chunk) {
         buf = buf ? Buffer.concat([buf, chunk]) : chunk
         if (isFirst && hasBom(buf)) {
@@ -193,10 +195,10 @@ function EventSource (url, eventSourceInitDict) {
           }
 
           var lineLength = -1
-          var fieldLength = -1
+          var fieldLength = startingFieldLength
           var c
 
-          for (var i = pos; lineLength < 0 && i < length; ++i) {
+          for (var i = startingPos; lineLength < 0 && i < length; ++i) {
             c = buf[i]
             if (c === colon) {
               if (fieldLength < 0) {
@@ -211,7 +213,12 @@ function EventSource (url, eventSourceInitDict) {
           }
 
           if (lineLength < 0) {
+            startingPos = length - pos
+            startingFieldLength = fieldLength
             break
+          } else {
+            startingPos = 0
+            startingFieldLength = -1
           }
 
           parseEventStreamLine(buf, pos, fieldLength, lineLength)

--- a/test/eventsource_test.js
+++ b/test/eventsource_test.js
@@ -466,6 +466,26 @@ describe('Parser', function () {
       }
     })
   })
+
+  it('parses a relatively huge message across many chunks efficiently', function (done) {
+    this.timeout(1000)
+
+    createServer(function (err, server) {
+      if (err) return done(err)
+
+      var longMessageContent = new Array(100000).join('a')
+      var longMessage = 'data: ' + longMessageContent + '\n\n'
+      var longMessageChunks = longMessage.match(/[\s\S]{1,10}/g) // Split the message into chunks of 10 characters
+      server.on('request', writeEvents(longMessageChunks))
+
+      var es = new EventSource(server.url)
+
+      es.onmessage = function (m) {
+        assert.equal(longMessageContent, m.data)
+        server.close(done)
+      }
+    })
+  })
 })
 
 describe('HTTP Request', function () {


### PR DESCRIPTION
Recently ran into an issue with large payloads (megabytes in size) that arrived over many chunks. As the size increased, the time to process them seemed to increase exponentially. After investigating a bit, realized that each time a new chunk arrives, any data in the buffer from before gets re-parsed. Thus, for very large messages you might wind up re-parsing the early data many times.

This change adds a couple variables to track data that has already been processed to skip evaluating it multiple times.