### PR TITLE
Fix issue: reconnection only happends for 1 time after connection drops

### DIFF
--- a/lib/eventsource.js
+++ b/lib/eventsource.js
@@ -242,6 +242,7 @@ function EventSource (url, eventSourceInitDict) {
     })
 
     req.on('error', function (err) {
+      self.connectionInProgress = false
       onConnectionClosed(err.message)
     })
 


### PR DESCRIPTION
Since the PR #125 fixed duplicate connections after reconnection by using a `connectionInProgress` lock to avoid function `connect()` be called duplicately.

But it forgot to release the `connectionInProgress` lock when request error happends, in that case, our client can only retry for 1 time and never get the lock again.

So it's needed to release the `connectionInProgress` lock when error happends.