### PR TITLE
Remove eventName from type declaration before emit

### DIFF
--- a/lib/eventsource.js
+++ b/lib/eventsource.js
@@ -268,7 +268,7 @@ function EventSource (url, eventSourceInitDict) {
   function parseEventStreamLine (buf, pos, fieldLength, lineLength) {
     if (lineLength === 0) {
       if (data.length > 0) {
-        var type = eventName || 'message'
+        var type = 'message'
         _emit(type, new MessageEvent(type, {
           data: data.slice(0, -1), // remove trailing newline
           lastEventId: lastEventId,


### PR DESCRIPTION
I tested using HackerNews firebase API, delete eventName solved my issue.

When you debug here eventName is put or open, etc. The emitter can't find listeners with that name, delete eventName and only use 'message' as type, then my code was working.

My code was
```
var EventSource = require("eventsource");
var eventSourceInitDict = { rejectUnauthorized: false };
var es = new EventSource(
  "https://hacker-news.firebaseio.com/v0/updates.json",
  eventSourceInitDict
);

es.onmessage = function (e) {
  console.log(e.data);
};
es.onerror = function (err) {
  console.log("ERROR!", err);
};

```