### PR TITLE
Add full URL to emit data

### DIFF
--- a/lib/eventsource.js
+++ b/lib/eventsource.js
@@ -272,7 +272,8 @@ function EventSource (url, eventSourceInitDict) {
         _emit(type, new MessageEvent(type, {
           data: data.slice(0, -1), // remove trailing newline
           lastEventId: lastEventId,
-          origin: original(url)
+          origin: original(url),
+          url: url
         }))
         data = ''
       }


### PR DESCRIPTION
Added the full path of the URL as information to identify the source of the event.
This is an alternative solution to #144