### PR TITLE
add GitHub build status badge to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # EventSource [![npm version](http://img.shields.io/npm/v/eventsource.svg?style=flat-square)](https://www.npmjs.com/package/eventsource)[![NPM Downloads](https://img.shields.io/npm/dm/eventsource.svg?style=flat-square)](http://npm-stat.com/charts.html?package=eventsource&from=2015-09-01)[![Dependencies](https://img.shields.io/david/EventSource/eventsource.svg?style=flat-square)](https://david-dm.org/EventSource/eventsource)
 
+![Build](https://github.com/EventSource/eventsource/actions/workflows/build.yml/badge.svg)
+
 This library is a pure JavaScript implementation of the [EventSource](https://html.spec.whatwg.org/multipage/server-sent-events.html#server-sent-events) client. The API aims to be W3C compatible.
 
 You can use it with Node.js or as a browser polyfill for


### PR DESCRIPTION
## Changes:

- Add GitHub build status badge to readme

## Context:

This badge shows the status of the `build.yml` workflow.