### PR TITLE
Create dependabot configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,11 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "daily"
+
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "daily"


### PR DESCRIPTION
## Changes: 

- Check for `npm` package updates (runs on every weekday, Monday to Friday)
- Check for `github-actions` updates (runs on every weekday, Monday to Friday)

## Context:

It's a good idea to check for updates for your packages and actions on a regular basis.
If you don't want to get bothered by Dependabot daily, I can also set the schedule to weekly or monthly checks.

I'm starting with a "default" Dependabot configuration so that you can tune it to your liking via suggestions.

Read the [GitHub docs, Configuration options for dependency updates](https://docs.github.com/en/code-security/supply-chain-security/configuration-options-for-dependency-updates) to learn more about the available configuration options.

The most likely things you'll want to change are probably:

- The schedule
- If it should check for `production` or `dev` updates only, or just all dependencies, or even just the lockfile
- If the PR should be assigned to somebody or ask for a review from somebody
- The timezone in which Dependabot runs
- Whether you want to use the default labels (`dependencies` + `github_actions` or `npm`) or set your own, or not use labels at all

So let me know what you want me to change to the configuration.

After you merge the PR, Dependabot will be activated for this repository automatically, and it will start checking for updates right away.