### PR TITLE
drop old node tests, add node 16 tests, bump engines in package.json

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,7 +12,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [0.12.x, 4.x, 6.x, 8.x, 12.x, 13.x, 14.x, 15.x]
+        node-version: [12.x, 13.x, 14.x, 15.x]
       fail-fast: false
 
     steps:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,7 +12,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [12.x, 13.x, 14.x, 15.x]
+        node-version: [12.x, 13.x, 14.x, 15.x, 16.x]
       fail-fast: false
 
     steps:

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "coverage": "nyc --reporter=html --reporter=text _mocha --reporter spec"
   },
   "engines": {
-    "node": ">=0.12.0"
+    "node": ">=12.0.0"
   },
   "dependencies": {
     "original": "^1.0.0"


### PR DESCRIPTION
## Changes:

- Drop Node 0.12.x, 4.x, 6.x, 8.x tests
- Bump `engines` to `>=12.0.0`
- Add Node 16 tests

## Context:

Closes #151. 