### PR TITLE
Only parse url if it's a string

### DIFF
--- a/lib/eventsource.js
+++ b/lib/eventsource.js
@@ -87,7 +87,10 @@ function EventSource (url, eventSourceInitDict) {
   var reconnectUrl = null
 
   function connect () {
-    var options = parse(url)
+    var options = url
+    if (typeof url === 'string') {
+      options = parse(url)
+    }
     var isSecure = options.protocol === 'https:'
     options.headers = { 'Cache-Control': 'no-cache', 'Accept': 'text/event-stream' }
     if (lastEventId) options.headers['Last-Event-ID'] = lastEventId


### PR DESCRIPTION
With this change we can use `eventsource` even when calling a server over a unix domain socket, for example: 

```javascript
const es = new EventSource({
  socketPath: 'some-socket.sock',
  path: '/my-path',
});
...
```
