### PR TITLE
add .github/ folder to npmignore

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,3 +1,4 @@
 test/
 .nyc_output/
 coverage/
+.github/


### PR DESCRIPTION
## Changes:

- add `.github/` folder to npmignore

## Context:

This should prevent publishing the contents of the `.github/` folder when you create a new release with npm.