### PR TITLE
adjust readme badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,9 @@
-# EventSource [![npm version](http://img.shields.io/npm/v/eventsource.svg?style=flat-square)](https://www.npmjs.com/package/eventsource)[![NPM Downloads](https://img.shields.io/npm/dm/eventsource.svg?style=flat-square)](http://npm-stat.com/charts.html?package=eventsource&from=2015-09-01)[![Dependencies](https://img.shields.io/david/EventSource/eventsource.svg?style=flat-square)](https://david-dm.org/EventSource/eventsource)
+# EventSource
 
-![Build](https://github.com/EventSource/eventsource/actions/workflows/build.yml/badge.svg)
+![build status](https://github.com/EventSource/eventsource/actions/workflows/build.yml/badge.svg)
+![npm version number](https://img.shields.io/npm/v/eventsource)
+![npm downloads per month](https://img.shields.io/npm/dm/eventsource)
+![npm license](https://img.shields.io/npm/l/eventsource)
 
 This library is a pure JavaScript implementation of the [EventSource](https://html.spec.whatwg.org/multipage/server-sent-events.html#server-sent-events) client. The API aims to be W3C compatible.
 


### PR DESCRIPTION
## Changes:

- Move badges so that they're under the `h1` of EventSource
- Make badges look like the GitHub build status badge
- Improve the alt text for the badges
- Create fresh badges from img.shield.io
- Add a npm license badge
- Remove "dependencies up to date" badge

## Context:

I think it looks a lot nicer this way, but feel free to disagree. 😄 