### PR TITLE
Preallocate buffer size when reading data

### DIFF
--- a/lib/eventsource.js
+++ b/lib/eventsource.js
@@ -16,7 +16,7 @@ var space = 32
 var lineFeed = 10
 var carriageReturn = 13
 // Beyond 256KB we could not observe any gain in performance
-var maxBufferAheadAllocation = 1024*256
+var maxBufferAheadAllocation = 1024 * 256
 
 function hasBom (buf) {
   return bom.every(function (charCode, index) {
@@ -182,6 +182,7 @@ function EventSource (url, eventSourceInitDict) {
       // text/event-stream parser adapted from webkit's
       // Source/WebCore/page/EventSource.cpp
       var buf
+      var newBuffer
       var startingPos = 0
       var startingFieldLength = -1
       var newBufferSize = 0
@@ -193,20 +194,20 @@ function EventSource (url, eventSourceInitDict) {
           if (hasBom(buf)) {
             buf = buf.slice(bom.length)
           }
+          bytesUsed = buf.length
         } else {
           if (chunk.length > buf.length - bytesUsed) {
             newBufferSize = (buf.length * 2) + chunk.length
             if (newBufferSize > maxBufferAheadAllocation) {
               newBufferSize = buf.length + chunk.length + maxBufferAheadAllocation
             }
-            newBuffer = new Buffer(newBufferSize)
+            newBuffer = Buffer.alloc(newBufferSize)
             buf.copy(newBuffer, 0, 0, bytesUsed)
             buf = newBuffer
           }
           chunk.copy(buf, bytesUsed)
+          bytesUsed += chunk.length
         }
-
-        bytesUsed += chunk.length
 
         var pos = 0
         var length = bytesUsed
@@ -253,6 +254,7 @@ function EventSource (url, eventSourceInitDict) {
 
         if (pos === length) {
           buf = void 0
+          bytesUsed = 0
         } else if (pos > 0) {
           buf = buf.slice(pos, bytesUsed)
           bytesUsed = buf.length

--- a/lib/eventsource.js
+++ b/lib/eventsource.js
@@ -15,6 +15,8 @@ var colon = 58
 var space = 32
 var lineFeed = 10
 var carriageReturn = 13
+// 1MB
+var maxBufferAheadAllocation = 1024*1024
 
 function hasBom (buf) {
   return bom.every(function (charCode, index) {
@@ -179,19 +181,35 @@ function EventSource (url, eventSourceInitDict) {
 
       // text/event-stream parser adapted from webkit's
       // Source/WebCore/page/EventSource.cpp
-      var isFirst = true
       var buf
       var startingPos = 0
       var startingFieldLength = -1
+      var newBufferSize = 0
+      var bytesUsed = 0
+
       res.on('data', function (chunk) {
-        buf = buf ? Buffer.concat([buf, chunk]) : chunk
-        if (isFirst && hasBom(buf)) {
-          buf = buf.slice(bom.length)
+        if (!buf) {
+          buf = chunk
+          if (hasBom(buf)) {
+            buf = buf.slice(bom.length)
+          }
+        } else {
+          if (chunk.length > buf.length - bytesUsed) {
+            newBufferSize = (buf.length * 2) + chunk.length
+            if (newBufferSize > maxBufferAheadAllocation) {
+              newBufferSize = buf.length + chunk.length + maxBufferAheadAllocation
+            }
+            newBuffer = new Buffer(newBufferSize)
+            buf.copy(newBuffer, 0, 0, bytesUsed)
+            buf = newBuffer
+          }
+          chunk.copy(buf, bytesUsed)
         }
 
-        isFirst = false
+        bytesUsed += chunk.length
+
         var pos = 0
-        var length = buf.length
+        var length = bytesUsed
 
         while (pos < length) {
           if (discardTrailingNewline) {
@@ -236,7 +254,8 @@ function EventSource (url, eventSourceInitDict) {
         if (pos === length) {
           buf = void 0
         } else if (pos > 0) {
-          buf = buf.slice(pos)
+          buf = buf.slice(pos, bytesUsed)
+          bytesUsed = buf.length
         }
       })
     })

--- a/lib/eventsource.js
+++ b/lib/eventsource.js
@@ -15,8 +15,7 @@ var colon = 58
 var space = 32
 var lineFeed = 10
 var carriageReturn = 13
-// 1MB
-var maxBufferAheadAllocation = 1024*1024
+var maxBufferAheadAllocation = 1024*256
 
 function hasBom (buf) {
   return bom.every(function (charCode, index) {

--- a/lib/eventsource.js
+++ b/lib/eventsource.js
@@ -15,6 +15,7 @@ var colon = 58
 var space = 32
 var lineFeed = 10
 var carriageReturn = 13
+// Beyond 256KB we could not observe any gain in performance
 var maxBufferAheadAllocation = 1024*256
 
 function hasBom (buf) {

--- a/test/eventsource_test.js
+++ b/test/eventsource_test.js
@@ -454,7 +454,7 @@ describe('Parser', function () {
   })
 
   it('parses relatively huge messages efficiently', function (done) {
-    this.timeout(1000)
+    this.timeout(30)
 
     createServer(function (err, server) {
       if (err) return done(err)

--- a/test/eventsource_test.js
+++ b/test/eventsource_test.js
@@ -454,7 +454,7 @@ describe('Parser', function () {
   })
 
   it('parses relatively huge messages efficiently', function (done) {
-    this.timeout(30)
+    this.timeout(200)
 
     createServer(function (err, server) {
       if (err) return done(err)


### PR DESCRIPTION
When small chunks are received from a large payload, i.e > 10MBs, performance
gets impacted because due to the buffer allocation, for payloads of 10MBs with
chunks of 2KBs it can take ~  20 seconds.

We add an exponential growth of the buffer providing enough room for subsequent
chunks until a maximum threshold of 1MB is reached

With that change we can see a x50 improvement with the trade off of having to
allocate a little extra space, worst case scenario 1MB.

Following is an example of the time needed for making the allocation of 10MB payload when chunks of 2K are received with the current implementation

```js
var buf
var chunk = Buffer.from('x'.repeat(2048))
var start = Date.now();
for (i=0; i<10_000_000/2048; i++) {
  buf = buf ? Buffer.concat([buf, chunk]) : chunk
}
var delta = Date.now() - start;
console.log(`Total time ${delta}ms`)
```

```bash
node /tmp/test_concat_buffer.js
Total time 17214ms
```