### PR TITLE
Make it again browser compatible

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,3 +1,7 @@
+# [2.0.1](https://github.com/EventSource/eventsource/compare/v2.0.0...v2.0.1)
+
+* Fix `URL is not a constructor` error for browser ([#268](https://github.com/EventSource/eventsource/pull/268) Ajinkya Rajput)
+
 # [2.0.0](https://github.com/EventSource/eventsource/compare/v1.1.0...v2.0.0)
 
 * BREAKING: Node >= 12 now required ([#152](https://github.com/EventSource/eventsource/pull/152) @HonkingGoose)

--- a/lib/eventsource.js
+++ b/lib/eventsource.js
@@ -1,5 +1,4 @@
 var parse = require('url').parse
-var URL = require('url').URL
 var events = require('events')
 var https = require('https')
 var http = require('http')

--- a/package.json
+++ b/package.json
@@ -52,6 +52,9 @@
   "standard": {
     "ignore": [
       "example/eventsource-polyfill.js"
+    ],
+    "globals": [
+      "URL"
     ]
   }
 }


### PR DESCRIPTION
After release 2.0.0, the [issue](https://github.com/EventSource/eventsource/issues/258) mentioned startup. Reason is nodejs built in package imports URL as variable but not in most of the url polyfill.

Solution: As URL class available in both nodejs and browser globally, we don't have to import it from url package. 