### PR TITLE
Feature: fix a number of redirect handling issues

### DIFF
--- a/lib/eventsource.js
+++ b/lib/eventsource.js
@@ -1,8 +1,10 @@
 var parse = require('url').parse
 var events = require('events')
-var https = require('https')
-var http = require('http')
 var util = require('util')
+var redirect = require('follow-redirects')
+
+var http = redirect.http
+var https = redirect.https
 
 var httpsOptions = [
   'pfx', 'key', 'passphrase', 'cert', 'ca', 'ciphers',
@@ -146,18 +148,14 @@ function EventSource (url, eventSourceInitDict) {
         return
       }
 
-      // Handle HTTP redirects
-      if (res.statusCode === 301 || res.statusCode === 302 || res.statusCode === 307) {
-        if (!res.headers.location) {
-          // Server sent redirect response without Location header.
-          _emit('error', new Event('error', {status: res.statusCode, message: res.statusMessage}))
-          return
-        }
-        if (res.statusCode === 307) reconnectUrl = url
-        url = res.headers.location
-        process.nextTick(connect)
-        return
+      // In case of temporary HTTP redirects, hold onto the original URL
+      if (res.statusCode === 302 || res.statusCode === 307) {
+        reconnectUrl = url
       }
+
+      // `responseUrl` is set by the `follow-redirects` module to either the original URL,
+      // or the target URL in case of HTTP redirects
+      url = res.responseUrl
 
       if (res.statusCode !== 200) {
         _emit('error', new Event('error', {status: res.statusCode, message: res.statusMessage}))

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,9 @@
       "name": "eventsource",
       "version": "2.0.1",
       "license": "MIT",
+      "dependencies": {
+        "follow-redirects": "^1.15.0"
+      },
       "devDependencies": {
         "buffer-from": "^1.1.1",
         "express": "^4.15.3",
@@ -2258,6 +2261,25 @@
       },
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/follow-redirects": {
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.0.tgz",
+      "integrity": "sha512-aExlJShTV4qOUOL7yF1U5tvLCB0xQuudbf6toyYA0E/acBNw71mvjFTnLaRp50aQaYocMR0a/RMMBIHeZnGyjQ==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/RubenVerborgh"
+        }
+      ],
+      "engines": {
+        "node": ">=4.0"
+      },
+      "peerDependenciesMeta": {
+        "debug": {
+          "optional": true
+        }
       }
     },
     "node_modules/for-in": {
@@ -12133,6 +12155,11 @@
         "rimraf": "~2.6.2",
         "write": "^0.2.1"
       }
+    },
+    "follow-redirects": {
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.0.tgz",
+      "integrity": "sha512-aExlJShTV4qOUOL7yF1U5tvLCB0xQuudbf6toyYA0E/acBNw71mvjFTnLaRp50aQaYocMR0a/RMMBIHeZnGyjQ=="
     },
     "for-in": {
       "version": "1.0.2",

--- a/package.json
+++ b/package.json
@@ -48,7 +48,9 @@
   "engines": {
     "node": ">=12.0.0"
   },
-  "dependencies": {},
+  "dependencies": {
+    "follow-redirects": "^1.15.0"
+  },
   "standard": {
     "ignore": [
       "example/eventsource-polyfill.js"

--- a/test/eventsource_test.js
+++ b/test/eventsource_test.js
@@ -581,6 +581,78 @@ describe('HTTP Request', function () {
       })
     })
 
+    it('follows http ' + status + ' redirect with only a path', function (done) {
+      var redirectSuffix = '/foobar'
+      var clientRequestedRedirectUrl = false
+      createServer(function (err, server) {
+        if (err) return done(err)
+
+        server.on('request', function (req, res) {
+          if (req.url === '/') {
+            res.writeHead(status, {
+              'Connection': 'Close',
+              'Location': redirectSuffix
+            })
+            res.end()
+          } else if (req.url === redirectSuffix) {
+            clientRequestedRedirectUrl = true
+            res.writeHead(200, {'Content-Type': 'text/event-stream'})
+            res.end()
+          }
+        })
+
+        var es = new EventSource(server.url)
+        es.onopen = function () {
+          assert.ok(clientRequestedRedirectUrl)
+          assert.equal(server.url + redirectSuffix, es.url)
+          server.close(done)
+        }
+      })
+    })
+
+    it('follows http ' + status + ' redirects, drops sensitive headers on origin change', function (done) {
+      var redirectSuffix = '/foobar'
+      var clientRequestedRedirectUrl = false
+      var receivedHeaders = {}
+      createServer(function (err, server) {
+        if (err) return done(err)
+
+        var newServerUrl = server.url.replace('http://localhost', 'http://127.0.0.1')
+
+        server.on('request', function (req, res) {
+          if (req.url === '/') {
+            res.writeHead(status, {
+              'Connection': 'Close',
+              'Location': newServerUrl + redirectSuffix
+            })
+            res.end()
+          } else if (req.url === redirectSuffix) {
+            clientRequestedRedirectUrl = true
+            receivedHeaders = req.headers
+            res.writeHead(200, {'Content-Type': 'text/event-stream'})
+            res.end()
+          }
+        })
+
+        var es = new EventSource(server.url, {
+          headers: {
+            keep: 'me',
+            authorization: 'Bearer someToken',
+            cookie: 'some-cookie=yep'
+          }
+        })
+
+        es.onopen = function () {
+          assert.ok(clientRequestedRedirectUrl)
+          assert.equal(newServerUrl + redirectSuffix, es.url)
+          assert.equal(receivedHeaders.keep, 'me', 'should keep safe headers')
+          assert.equal(typeof receivedHeaders.authorization, 'undefined', 'should strip auth')
+          assert.equal(typeof receivedHeaders.cookie, 'undefined', 'should strip cookie')
+          server.close(done)
+        }
+      })
+    })
+
     it('causes error event when response is ' + status + ' with missing location', function (done) {
       createServer(function (err, server) {
         if (err) return done(err)


### PR DESCRIPTION
When requesting an eventsource endpoint and defining custom, sensitive headers, such as `Authorization` and `Cookie`, these headers should not be forwarded when redirecting to a different origin than the original.

While looking in to fixing this, I discovered that the current redirect handling also does not support relative URLs in the `Location` header (eg `Location: /some/other/path`), nor does it set any limit on the maximum number of redirects. Instead of attempting to patch all these shortcomings, I feel we are better suited by utilizing the [follow-redirects](https://github.com/follow-redirects/follow-redirects) module, which handles all of these cases and is widely used.

