### PR TITLE
Fix: strip sensitive headers on redirect to different origin

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,3 +1,7 @@
+# [2.0.2](https://github.com/EventSource/eventsource/compare/v2.0.1...v2.0.2)
+
+* Do not include authorization and cookie headers on redirect to different origin ([#273](https://github.com/EventSource/eventsource/pull/273) Espen Hovlandsdal)
+
 # [2.0.1](https://github.com/EventSource/eventsource/compare/v2.0.0...v2.0.1)
 
 * Fix `URL is not a constructor` error for browser ([#268](https://github.com/EventSource/eventsource/pull/268) Ajinkya Rajput)
@@ -7,6 +11,10 @@
 * BREAKING: Node >= 12 now required ([#152](https://github.com/EventSource/eventsource/pull/152) @HonkingGoose)
 * Preallocate buffer size when reading data for increased performance with large messages ([#239](https://github.com/EventSource/eventsource/pull/239) Pau Freixes)
 * Removed dependency on url-parser. Fixes [CVE-2022-0512](https://www.whitesourcesoftware.com/vulnerability-database/CVE-2022-0512) & [CVE-2022-0691](https://nvd.nist.gov/vuln/detail/CVE-2022-0691) ([#249](https://github.com/EventSource/eventsource/pull/249) Alex Hladin)
+
+# [1.1.1](https://github.com/EventSource/eventsource/compare/v1.1.0...v1.1.1)
+
+* Do not include authorization and cookie headers on redirect to different origin ([#273](https://github.com/EventSource/eventsource/pull/273) Espen Hovlandsdal)
 
 # [1.1.0](https://github.com/EventSource/eventsource/compare/v1.0.7...v1.1.0)
 

--- a/lib/eventsource.js
+++ b/lib/eventsource.js
@@ -32,6 +32,8 @@ function hasBom (buf) {
  **/
 function EventSource (url, eventSourceInitDict) {
   var readyState = EventSource.CONNECTING
+  var headers = eventSourceInitDict && eventSourceInitDict.headers
+  var hasNewOrigin = false
   Object.defineProperty(this, 'readyState', {
     get: function () {
       return readyState
@@ -53,11 +55,12 @@ function EventSource (url, eventSourceInitDict) {
     readyState = EventSource.CONNECTING
     _emit('error', new Event('error', {message: message}))
 
-    // The url may have been changed by a temporary
-    // redirect. If that's the case, revert it now.
+    // The url may have been changed by a temporary redirect. If that's the case,
+    // revert it now, and flag that we are no longer pointing to a new origin
     if (reconnectUrl) {
       url = reconnectUrl
       reconnectUrl = null
+      hasNewOrigin = false
     }
     setTimeout(function () {
       if (readyState !== EventSource.CONNECTING || self.connectionInProgress) {
@@ -70,9 +73,9 @@ function EventSource (url, eventSourceInitDict) {
 
   var req
   var lastEventId = ''
-  if (eventSourceInitDict && eventSourceInitDict.headers && eventSourceInitDict.headers['Last-Event-ID']) {
-    lastEventId = eventSourceInitDict.headers['Last-Event-ID']
-    delete eventSourceInitDict.headers['Last-Event-ID']
+  if (headers && headers['Last-Event-ID']) {
+    lastEventId = headers['Last-Event-ID']
+    delete headers['Last-Event-ID']
   }
 
   var discardTrailingNewline = false
@@ -86,9 +89,10 @@ function EventSource (url, eventSourceInitDict) {
     var isSecure = options.protocol === 'https:'
     options.headers = { 'Cache-Control': 'no-cache', 'Accept': 'text/event-stream' }
     if (lastEventId) options.headers['Last-Event-ID'] = lastEventId
-    if (eventSourceInitDict && eventSourceInitDict.headers) {
-      for (var i in eventSourceInitDict.headers) {
-        var header = eventSourceInitDict.headers[i]
+    if (headers) {
+      var reqHeaders = hasNewOrigin ? removeUnsafeHeaders(headers) : headers
+      for (var i in reqHeaders) {
+        var header = reqHeaders[i]
         if (header) {
           options.headers[i] = header
         }
@@ -148,13 +152,17 @@ function EventSource (url, eventSourceInitDict) {
 
       // Handle HTTP redirects
       if (res.statusCode === 301 || res.statusCode === 302 || res.statusCode === 307) {
-        if (!res.headers.location) {
+        var location = res.headers.location
+        if (!location) {
           // Server sent redirect response without Location header.
           _emit('error', new Event('error', {status: res.statusCode, message: res.statusMessage}))
           return
         }
+        var prevOrigin = new URL(url).origin
+        var nextOrigin = new URL(location).origin
+        hasNewOrigin = prevOrigin !== nextOrigin
         if (res.statusCode === 307) reconnectUrl = url
-        url = res.headers.location
+        url = location
         process.nextTick(connect)
         return
       }
@@ -462,4 +470,24 @@ function MessageEvent (type, eventInitDict) {
       Object.defineProperty(this, f, { writable: false, value: eventInitDict[f], enumerable: true })
     }
   }
+}
+
+/**
+ * Returns a new object of headers that does not include any authorization and cookie headers
+ *
+ * @param {Object} headers An object of headers ({[headerName]: headerValue})
+ * @return {Object} a new object of headers
+ * @api private
+ */
+function removeUnsafeHeaders (headers) {
+  var safe = {}
+  for (var key in headers) {
+    if (/^(cookie|authorization)$/i.test(key)) {
+      continue
+    }
+
+    safe[key] = headers[key]
+  }
+
+  return safe
 }

--- a/lib/eventsource.js
+++ b/lib/eventsource.js
@@ -16,6 +16,8 @@ var lineFeed = 10
 var carriageReturn = 13
 // Beyond 256KB we could not observe any gain in performance
 var maxBufferAheadAllocation = 1024 * 256
+// Headers matching the pattern should be removed when redirecting to different origin
+var reUnsafeHeader = /^(cookie|authorization)$/i
 
 function hasBom (buf) {
   return bom.every(function (charCode, index) {
@@ -482,7 +484,7 @@ function MessageEvent (type, eventInitDict) {
 function removeUnsafeHeaders (headers) {
   var safe = {}
   for (var key in headers) {
-    if (/^(cookie|authorization)$/i.test(key)) {
+    if (reUnsafeHeader.test(key)) {
       continue
     }
 


### PR DESCRIPTION
I originally sent a PR for this as #271, but it fixed a number of issues related to the redirect handling which _could_ be considered breaking - and also added a dependency. After giving @joeybaker's [review](https://github.com/EventSource/eventsource/pull/271#pullrequestreview-968059281) some thought, I am really eager to get a _patch_ release out for this issue, as I don't want to leave the entire 2.x range with a security issue. 

This PR attempts to address _only_ the security issue, and does so in a way that should be backwards compatible. I still think we should improve the redirect handling overall, so I have renamed #271 to be more descriptive about this.

In other words, I want to merge _this_ PR first, release a patch release on the 2.x range (potentially also backporting it to 1.x). Later on, I want to merge #271 and do a major release for that - but there is no rush with that one.
