### PR TITLE
Use native EventSource in browsers

### DIFF
--- a/browser.js
+++ b/browser.js
@@ -1,0 +1,1 @@
+module.exports = window.EventSource

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "lib": "./lib"
   },
   "main": "./lib/eventsource",
+  "browser": "browser.js",
   "license": "MIT",
   "licenses": [
     {


### PR DESCRIPTION
Hi,
this PR adds a `browser` field to `package.json`, with a `browser.js` that re-exports `window.EventSource` in CommonJS format. This makes the package easily compatible with CommonJS based bundlers (e.g. vite).