### PR TITLE
Fix: `dispatchEvent` wrong implementation

### DIFF
--- a/lib/eventsource.js
+++ b/lib/eventsource.js
@@ -421,9 +421,8 @@ EventSource.prototype.dispatchEvent = function dispatchEvent (event) {
   if (!event.type) {
     throw new Error('UNSPECIFIED_EVENT_TYPE_ERR')
   }
-  // if event is instance of an CustomEvent (or has 'details' property),
-  // send the detail object as the payload for the event
-  this.emit(event.type, event.detail)
+
+  this.emit(event.type, event)
 }
 
 /**

--- a/test/eventsource_test.js
+++ b/test/eventsource_test.js
@@ -1314,7 +1314,7 @@ describe('Events', function () {
         server.close(done)
       })
 
-      es.dispatchEvent({type: 'greeting', detail: {data: 'Hello'}})
+      es.dispatchEvent({type: 'greeting', data: 'Hello'})
     })
   })
 })


### PR DESCRIPTION
Fixes #288 

The function now emits the entire `Event` object and not only `CustomEvent.detail` as described in W3C specs (see issue).
**It is a breaking change for projects that use the current wrong implementation.**