### PR TITLE
Adding support for payloads and HTTP methods other than GET.

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,16 @@ You can define a `proxy` option for the HTTP request to be used. This is typical
 var es = new EventSource(url, {proxy: 'http://your.proxy.com'});
 ```
 
+### HTTP methods other than GET
+
+You can define an optional payload, and a method for the HTTP request to be used. The method defaults to `GET`,
+unless a payload is given, in which case it defaults to `POST`. It can however be overridden in the `eventSourceInitDict`.
+The payload can be any JavaScript value, which will be automatically stringified for transmission.
+
+```javascript
+var es = new EventSource(url, {method: 'POST', payload: {hello: 'world!'}});
+```
+
 
 ## License
 

--- a/lib/eventsource.js
+++ b/lib/eventsource.js
@@ -143,6 +143,21 @@ function EventSource (url, eventSourceInitDict) {
       options.withCredentials = eventSourceInitDict.withCredentials
     }
 
+    // If a HTTP method was specified, add it to the request options
+    // If no method is given, but a payload is provided, assume method POST
+    if (eventSourceInitDict && eventSourceInitDict.method) {
+      options.method = eventSourceInitDict.method
+    } else if (eventSourceInitDict && eventSourceInitDict.payload) {
+      options.method = 'POST'
+
+    // If a payload is provided, set the content headers
+    let payload
+    if (eventSourceInitDict && eventSourceInitDict.payload) {
+      payload = JSON.stringify(eventSourceInitDict.payload)
+      options.headers['Content-Type'] = 'application/json'
+      options.headers['Content-Length'] = new global.TextEncoder().encode(payload).length
+    }
+
     req = (isSecure ? https : http).request(options, function (res) {
       self.connectionInProgress = false
       // Handle HTTP errors
@@ -277,6 +292,7 @@ function EventSource (url, eventSourceInitDict) {
     })
 
     if (req.setNoDelay) req.setNoDelay(true)
+    if (payload) req.write(payload)
     req.end()
   }
 

--- a/test/eventsource_test.js
+++ b/test/eventsource_test.js
@@ -549,6 +549,64 @@ describe('HTTP Request', function () {
         }
       )
     })
+  })
+
+  it('sends payloads with default POST method', function (done) {
+    createServer(function (err, server) {
+      if (err) return done(err)
+
+      server.on('request', function (req) {
+        assert.equal(req.headers['content-type'], 'application/json')
+        assert.equal(req.headers['content-length'], '17')
+        assert.equal(req.method, 'POST')
+
+        let body = ''
+        req.setEncoding('utf8')
+        req
+          .on('data', (data) => {
+            body += data
+          })
+          .on('end', (data) => {
+            assert.equal(body, '{"hello":"world"}')
+            server.close(done)
+          })
+      })
+
+      assert.doesNotThrow(
+        function () {
+          new EventSource(server.url, {payload: {hello: 'world'}})
+        }
+      )
+    })
+  })
+
+  it('sends payloads with custom PUT method', function (done) {
+    createServer(function (err, server) {
+      if (err) return done(err)
+
+      server.on('request', function (req) {
+        assert.equal(req.headers['content-type'], 'application/json')
+        assert.equal(req.headers['content-length'], '17')
+        assert.equal(req.method, 'PUT')
+
+        let body = ''
+        req.setEncoding('utf8')
+        req
+          .on('data', (data) => {
+            body += data
+          })
+          .on('end', (data) => {
+            assert.equal(body, '{"hello":"world"}')
+            server.close(done)
+          })
+      })
+
+      assert.doesNotThrow(
+        function () {
+          new EventSource(server.url, {method: 'PUT', payload: {hello: 'world'}})
+        }
+      )
+    })
   });
 
   [301, 302, 307].forEach(function (status) {


### PR DESCRIPTION
These changes introduce support for HTTP methods other than GET, for example POST and PUT, and related payloads. Inspired by [sse.js](https://github.com/mpetazzoni/sse.js#making-a-post-request-and-overriding-the-http-method). Note that the standard does not directly support this functionality, however there is no technical reason against it (as discussed [here](https://stackoverflow.com/questions/34261928/can-server-sent-events-sse-with-eventsource-pass-parameter-by-post)): it is therefore to be considered as a custom extension, in similar way to [others provided by this package](https://github.com/EventSource/eventsource#extensions-to-the-w3c-api).

Technically, the new code adds support for two new properties of the `eventSourceInitDict`:
```javascript
{
  method: 'POST',              // optional, defaults to GET when there is no payload, or to POST otherwise
  payload: { hello: 'world' }  // optional, defaults to no data
}
```