### PR TITLE
Run CI on Node 17 and 18

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,7 +12,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [12.x, 13.x, 14.x, 15.x, 16.x]
+        node-version: [12.x, 13.x, 14.x, 15.x, 16.x, 17.x, 18.x]
       fail-fast: false
 
     steps:


### PR DESCRIPTION
The ssl tests are failing on Node 17 and 18. I think we need to create new certs. How to do this should be automated, or at least documented.