### PR TITLE
Set request method: GET

### DIFF
--- a/lib/eventsource.js
+++ b/lib/eventsource.js
@@ -90,6 +90,7 @@ function EventSource (url, eventSourceInitDict) {
     var options = parse(url)
     var isSecure = options.protocol === 'https:'
     options.headers = { 'Cache-Control': 'no-cache', 'Accept': 'text/event-stream' }
+    options.method = 'GET'
     if (lastEventId) options.headers['Last-Event-ID'] = lastEventId
     if (headers) {
       var reqHeaders = hasNewOrigin ? removeUnsafeHeaders(headers) : headers


### PR DESCRIPTION
Solves issue when uses with Msw library caused by this: [link](https://github.com/mswjs/interceptors/blob/main/src/interceptors/ClientRequest/utils/normalizeClientRequestArgs.ts#L122)

Request headers are not sent when using the Msw library. Example:

```js
const http = require('http')
const parse = require('url').parse // DEPRECATED !!
const setupServer = require('msw/node').setupServer

const server = setupServer()

beforeAll(() => {
  server.listen()
})

afterAll(() => {
  server.close()
})

it.only('test', async () => {
  const url = parse('/')
  url.protocol = 'http:'
  url.host = '127.0.0.1'
  url.hostname = '127.0.0.1'
  url.port = '3000'
  url.headers = {test: 'test'}
  url.href = 'http://127.0.0.1:3000/'
  // url.method = 'GET' // resolves the issue

  const req = http.request(url, res => {
    console.log(`STATUS: ${res.statusCode}`)
  })

  req.end()
})
```

Also it is sending `hash` parameter to `null` because it is using `url.parse` which by the way is deprecated: [link](https://nodejs.org/api/url.html#legacy-url-api):

![image](https://github.com/EventSource/eventsource/assets/1703608/8099aaa1-9d6b-44b0-9084-f6aa6e4905de)




