### PR TITLE
Fix parsing of lines with mixed terminators.

### DIFF
--- a/lib/eventsource.js
+++ b/lib/eventsource.js
@@ -232,8 +232,9 @@ function EventSource (url, eventSourceInitDict) {
           var lineLength = -1
           var fieldLength = startingFieldLength
           var c
+          var i
 
-          for (var i = startingPos; lineLength < 0 && i < length; ++i) {
+          for (i = startingPos; lineLength < 0 && i < length; ++i) {
             c = buf[i]
             if (c === colon) {
               if (fieldLength < 0) {
@@ -252,7 +253,7 @@ function EventSource (url, eventSourceInitDict) {
             startingFieldLength = fieldLength
             break
           } else {
-            startingPos = 0
+            startingPos = i
             startingFieldLength = -1
           }
 


### PR DESCRIPTION
Fixes issue #326.

When parsing a packet received from the server, the parser is restarting from the start of the packet when parsing each line, rather than starting from the current packet offset.

This PR updates the starting position to the last index, instead of a value of zero.