### PR TITLE
fix: Add compatibility mode option to disable Content-Type header checking

### DIFF
--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -85,3 +85,15 @@ The default reconnect timeout is now 3 seconds - up from 1 second in v1/v2. This
 Redirect handling now matches Chrome/Safari. On disconnects, we will always reconnect to the _original_ URL. In v1/v2, only HTTP 307 would reconnect to the original, while 301 and 302 would both redirect to the _destination_.
 
 While the _ideal_ behavior would be for 301 and 308 to reconnect to the redirect _destination_, and 302/307 to reconnect to the _original_ URL, this is not possible to do cross-platform (cross-origin requests in browsers do not allow reading location headers, and redirect handling will have to be done manually).
+
+#### Strict checking of Content-Type header
+
+The Content-Type header is now checked. It's value must be `text/event-stream`, and the connection will be failed otherwise.
+
+To maintain the previous behaviour, set `strictContentType: false` when constructing EventSources:
+
+```ts
+const es = new EventSource('https://my-server.com/sse', {
+  strictContentType: false
+})
+```

--- a/src/types.ts
+++ b/src/types.ts
@@ -81,6 +81,12 @@ export interface EventSourceInit {
   withCredentials?: boolean
 
   /**
+   * A boolean value, defaulting to `true`, indicating if strict enforcement of 'Content-Type' header should be enabled.
+   * If this is true, connections will fail and not reconnect unless a `Content-Type: text/event-stream` header is returned.
+   */
+  strictContentType?: boolean
+
+  /**
    * Optional fetch implementation to use. Defaults to `globalThis.fetch`.
    * Can also be used for advanced use cases like mocking, proxying, custom certs etc.
    */


### PR DESCRIPTION
This was a breaking change with v3 that's hard to work around when you have broken APIs. I've added a config option to allow use of this library where it was possible to do so before.

Add relevant information to migration guide so users are aware of the breaking change.