### PR TITLE
devex: suppress tsc err

### DIFF
--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -39,7 +39,7 @@ const es = new EventSource('https://my-server.com/sse', {
 -  headers: {Authorization: 'Bearer foobar'}
 +  fetch: (input, init) => fetch(input, {
 +    ...init,
-+    headers: {...init.headers, Authorization: 'Bearer foobar'},
++    headers: { ...(init?.headers ?? {}), Authorization: 'Bearer foobar'},
 +  }),
 })
 ```

--- a/README.md
+++ b/README.md
@@ -125,7 +125,7 @@ const es = new EventSource('https://my-server.com/sse', {
     fetch(input, {
       ...init,
       headers: {
-        ...init.headers,
+        ...(init?.headers ?? {}),
         Authorization: 'Bearer myToken',
       },
     }),

--- a/test/tests.ts
+++ b/test/tests.ts
@@ -489,7 +489,7 @@ export function registerTests(options: {
         fetch(dstUrl, init) {
           return request(dstUrl, {
             ...init,
-            headers: {...init?.headers, authorization: 'Bearer foo'},
+            headers: {...(init?.headers ?? {}), authorization: 'Bearer foo'},
           })
         },
       })
@@ -549,7 +549,7 @@ export function registerTests(options: {
         fetch(dstUrl, init) {
           return request(dstUrl, {
             ...init,
-            headers: {...init?.headers, authorization: 'Bearer foo'},
+            headers: {...(init?.headers ?? {}), authorization: 'Bearer foo'},
           })
         },
       })


### PR DESCRIPTION
## Changes

In both tests and documentation, ensure headers are safely spread by handling undefined or null values using the nullish coalescing operator. This suppresses TypeScript errors related to potentially undefined `init.headers`.

## Before

<img width="461" alt="image" src="https://github.com/user-attachments/assets/26a60574-89b6-4ae6-8b2a-c626e32913f1" />
