### PR TITLE
fix(types): make the public EventSource type structural

### DIFF
--- a/.changeset/decode-chunk-narrowing.md
+++ b/.changeset/decode-chunk-narrowing.md
@@ -1,0 +1,11 @@
+---
+'eventsource': minor
+---
+
+Typed response body chunks as buffers instead of `unknown`
+
+`ReaderLike` typed chunks read off the response body as `unknown`, but they are handed to a `TextDecoder`, which only accepts buffers and throws on anything else. So a reader yielding anything else was never usable, and the type said otherwise. It also hid a type error in the client itself, which only surfaces when compiling against TypeScript's `dom` library: the node typings resolve the chunk to `any`, while the `dom` library resolves it to `{}`.
+
+Chunks are now typed as `Uint8Array | DataView | ArrayBuffer`, which is what both the node and DOM typings accept, and which every `fetch()` implementation yields. Nothing changes at runtime.
+
+If you pass a custom `fetch()` that returns a hand-rolled body, and your reader's chunk type is wider than the above, eg `unknown` or `any`, it will no longer be assignable. Returning a real `Response`, or a reader that yields `Uint8Array` chunks, is unaffected.

--- a/.changeset/handler-this-type.md
+++ b/.changeset/handler-this-type.md
@@ -1,0 +1,15 @@
+---
+'eventsource': minor
+---
+
+Declared the `this` type for the `onerror`, `onmessage` and `onopen` properties
+
+`addEventListener()` already declared that listeners are called with the EventSource instance as `this`, but the `on*` properties did not, so `this` was an implicit `any` in handlers assigned to them (an error under `noImplicitThis`). They now match `addEventListener()` and the native `EventSource`:
+
+```ts
+eventSource.onmessage = function (event) {
+  console.log(this.url, event.data) // `this` is now typed
+}
+```
+
+Handlers that declare an incompatible `this`, eg an unbound class method typed with `this: MyClass`, will now be rejected where they were previously accepted. Arrow functions and handlers that ignore `this` are unaffected.

--- a/.changeset/structural-eventsource-type.md
+++ b/.changeset/structural-eventsource-type.md
@@ -1,0 +1,15 @@
+---
+'eventsource': minor
+---
+
+Made the exported `EventSource` type structural, so other implementations can satisfy it
+
+`EventSource` was exported as a class holding hard-private (`#`) fields, which makes TypeScript emit a `#private` brand into the declaration file and turns the exported type nominal. A consumer writing `function connect(es: EventSource)` against this package could not pass the native `EventSource`, a mock, or any other implementation, even when the shape matched exactly.
+
+The implementation class is now internal, and `EventSource` is exported as an `interface` plus a const holding the constructor. As a result:
+
+- The native `EventSource`, along with mocks and stubs, is assignable to the exported `EventSource` type
+- The exported value and `globalThis.EventSource` are interchangeable in both directions, which helps libraries that accept an EventSource implementation to construct
+- A new `EventSourceConstructor` type is exported for that case
+
+Nothing changes at runtime: `new EventSource(...)`, `instanceof`, subclassing, the readyState statics, `EventSource.name`, inspected output and the `eventsource.supports-fetch-override` symbol all behave as before, and the internal state is still held in real `#private` fields.

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -64,6 +64,20 @@ jobs:
       - name: Run tests
         run: npm run test:node
 
+  testTypes:
+    name: 'Test: Types'
+    timeout-minutes: 15
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+      - uses: actions/setup-node@v7
+        with:
+          node-version: 24
+      - name: Install dependencies
+        run: npm ci
+      - name: Check type compatibility
+        run: npm run test:types
+
   testDeno:
     name: 'Test: Deno'
     timeout-minutes: 15

--- a/package.json
+++ b/package.json
@@ -24,11 +24,12 @@
     "prebuild": "npm run clean",
     "prepare": "npm run build",
     "release": "changeset publish",
-    "test": "npm run test:node && npm run test:browser",
+    "test": "npm run test:types && npm run test:node && npm run test:browser",
     "test:browser": "node test/browser/client.browser.test.ts",
     "test:bun": "bun run test/bun/client.bun.test.ts",
     "test:deno": "deno run --allow-net --allow-read --allow-env --unstable-sloppy-imports test/deno/client.deno.test.ts",
     "test:node": "node test/node/client.node.test.ts",
+    "test:types": "npm run build && tsc -p tsconfig.types.json",
     "version:packages": "changeset version && npm install --package-lock-only --no-audit --no-fund"
   },
   "files": [

--- a/src/EventSource.ts
+++ b/src/EventSource.ts
@@ -23,6 +23,9 @@ const DEFAULT_MAX_BUFFER_SIZE = 100 * 1024 * 1024
  * An `EventSource` instance opens a persistent connection to an HTTP server, which sends events
  * in `text/event-stream` format. The connection remains open until closed by calling `.close()`.
  *
+ * Deliberately an `interface` and not a `class`: it lets consumers pass the native `EventSource`,
+ * a mock, or any other implementation wherever this type is expected.
+ *
  * @public
  * @example
  * ```js
@@ -35,48 +38,27 @@ const DEFAULT_MAX_BUFFER_SIZE = 100 * 1024 * 1024
  * })
  * ```
  */
-export class EventSource extends EventTarget {
+export interface EventSource extends EventTarget {
   /**
    * ReadyState representing an EventSource currently trying to connect
    *
    * @public
    */
-  static CONNECTING = 0 as const
+  readonly CONNECTING: 0
 
   /**
    * ReadyState representing an EventSource connection that is open (eg connected)
    *
    * @public
    */
-  static OPEN = 1 as const
+  readonly OPEN: 1
 
   /**
    * ReadyState representing an EventSource connection that is closed (eg disconnected)
    *
    * @public
    */
-  static CLOSED = 2 as const
-
-  /**
-   * ReadyState representing an EventSource currently trying to connect
-   *
-   * @public
-   */
-  readonly CONNECTING = 0 as const
-
-  /**
-   * ReadyState representing an EventSource connection that is open (eg connected)
-   *
-   * @public
-   */
-  readonly OPEN = 1 as const
-
-  /**
-   * ReadyState representing an EventSource connection that is closed (eg disconnected)
-   *
-   * @public
-   */
-  readonly CLOSED = 2 as const
+  readonly CLOSED: 2
 
   /**
    * Returns the state of this EventSource object's connection. It can have the values described below.
@@ -88,9 +70,7 @@ export class EventSource extends EventTarget {
    *
    * @public
    */
-  public get readyState(): number {
-    return this.#readyState
-  }
+  readonly readyState: number
 
   /**
    * Returns the URL providing the event stream.
@@ -99,20 +79,128 @@ export class EventSource extends EventTarget {
    *
    * @public
    */
-  public get url(): string {
-    return this.#url.href
-  }
+  readonly url: string
 
   /**
    * Returns true if the credentials mode for connection requests to the URL providing the event stream is set to "include", and false otherwise.
    *
    * [MDN Reference](https://developer.mozilla.org/docs/Web/API/EventSource/withCredentials)
+   *
+   * @public
    */
+  readonly withCredentials: boolean
+
+  /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/EventSource/error_event) */
+  onerror: ((ev: ErrorEvent) => unknown) | null
+
+  /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/EventSource/message_event) */
+  onmessage: ((ev: MessageEvent) => unknown) | null
+
+  /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/EventSource/open_event) */
+  onopen: ((ev: Event) => unknown) | null
+
+  addEventListener<K extends keyof EventSourceEventMap>(
+    type: K,
+    listener: (this: EventSource, ev: EventSourceEventMap[K]) => unknown,
+    options?: boolean | AddEventListenerOptions,
+  ): void
+  addEventListener(
+    type: string,
+    listener: (this: EventSource, event: MessageEvent) => unknown,
+    options?: boolean | AddEventListenerOptions,
+  ): void
+  addEventListener(
+    type: string,
+    listener: EventListenerOrEventListenerObject,
+    options?: boolean | AddEventListenerOptions,
+  ): void
+
+  removeEventListener<K extends keyof EventSourceEventMap>(
+    type: K,
+    listener: (this: EventSource, ev: EventSourceEventMap[K]) => unknown,
+    options?: boolean | EventListenerOptions,
+  ): void
+  removeEventListener(
+    type: string,
+    listener: (this: EventSource, event: MessageEvent) => unknown,
+    options?: boolean | EventListenerOptions,
+  ): void
+  removeEventListener(
+    type: string,
+    listener: EventListenerOrEventListenerObject,
+    options?: boolean | EventListenerOptions,
+  ): void
+
+  /**
+   * Aborts any instances of the fetch algorithm started for this EventSource object, and sets the readyState attribute to CLOSED.
+   *
+   * [MDN Reference](https://developer.mozilla.org/docs/Web/API/EventSource/close)
+   *
+   * @public
+   */
+  close(): void
+}
+
+/**
+ * The `EventSource` constructor. Mirrors the shape of the native one, so the two can be used
+ * interchangeably - eg for functions that take an implementation to construct.
+ *
+ * @public
+ */
+export interface EventSourceConstructor {
+  readonly prototype: EventSource
+
+  /**
+   * Constructs a new `EventSource` instance, which immediately starts connecting.
+   *
+   * @param url - The URL to connect to
+   * @param eventSourceInitDict - Options for the connection
+   */
+  new (url: string | URL, eventSourceInitDict?: EventSourceInit): EventSource
+
+  /** ReadyState representing an EventSource currently trying to connect */
+  readonly CONNECTING: 0
+
+  /** ReadyState representing an EventSource connection that is open (eg connected) */
+  readonly OPEN: 1
+
+  /** ReadyState representing an EventSource connection that is closed (eg disconnected) */
+  readonly CLOSED: 2
+}
+
+/**
+ * Implementation of the `EventSource` interface.
+ *
+ * Intentionally not exported: TypeScript emits a `#private` brand into declaration files for any
+ * class holding hard-private (`#`) fields, which makes the emitted type nominal. Exporting the
+ * interface and const instead keeps the public type structural, while the implementation keeps
+ * its actual, runtime-enforced private state.
+ *
+ * Public members are documented on the `EventSource` interface, which is what consumers see.
+ *
+ * @internal
+ */
+class EventSourceImpl extends EventTarget implements EventSource {
+  static CONNECTING = 0 as const
+  static OPEN = 1 as const
+  static CLOSED = 2 as const
+
+  readonly CONNECTING = 0 as const
+  readonly OPEN = 1 as const
+  readonly CLOSED = 2 as const
+
+  public get readyState(): number {
+    return this.#readyState
+  }
+
+  public get url(): string {
+    return this.#url.href
+  }
+
   public get withCredentials(): boolean {
     return this.#withCredentials
   }
 
-  /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/EventSource/error_event) */
   public get onerror(): ((ev: ErrorEvent) => unknown) | null {
     return this.#onError
   }
@@ -126,7 +214,6 @@ export class EventSource extends EventTarget {
     }
   }
 
-  /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/EventSource/message_event) */
   public get onmessage(): ((ev: MessageEvent) => unknown) | null {
     return this.#onMessage
   }
@@ -140,7 +227,6 @@ export class EventSource extends EventTarget {
     }
   }
 
-  /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/EventSource/open_event) */
   public get onopen(): ((ev: Event) => unknown) | null {
     return this.#onOpen
   }
@@ -236,13 +322,6 @@ export class EventSource extends EventTarget {
     this.#connect()
   }
 
-  /**
-   * Aborts any instances of the fetch algorithm started for this EventSource object, and sets the readyState attribute to CLOSED.
-   *
-   * [MDN Reference](https://developer.mozilla.org/docs/Web/API/EventSource/close)
-   *
-   * @public
-   */
   close(): void {
     if (this.#reconnectTimer) clearTimeout(this.#reconnectTimer)
     if (this.#readyState === this.CLOSED) return
@@ -626,14 +705,37 @@ export class EventSource extends EventTarget {
   }
 }
 
+// The class is named `EventSourceImpl` to leave the `EventSource` name free for the interface and
+// the const below. Restore the public name, so neither `EventSource.name` nor inspected instances
+// (eg `console.log(eventSource)`) leak the implementation name.
+Object.defineProperty(EventSourceImpl, 'name', {value: 'EventSource'})
+
 // Provides a way to detect that the EventSource implementation supports passing `fetch`
 // that can be used to customize the request, eg custom headers and similar.
-Object.defineProperty(EventSource, Symbol.for('eventsource.supports-fetch-override'), {
+Object.defineProperty(EventSourceImpl, Symbol.for('eventsource.supports-fetch-override'), {
   value: true,
   writable: false,
   configurable: false,
   enumerable: false,
 })
+
+/**
+ * An `EventSource` instance opens a persistent connection to an HTTP server, which sends events
+ * in `text/event-stream` format. The connection remains open until closed by calling `.close()`.
+ *
+ * @public
+ * @example
+ * ```js
+ * const eventSource = new EventSource('https://example.com/stream')
+ * eventSource.addEventListener('error', (error) => {
+ *   console.error(error)
+ * })
+ * eventSource.addEventListener('message', (event) => {
+ *  console.log('Received message:', event.data)
+ * })
+ * ```
+ */
+export const EventSource: EventSourceConstructor = EventSourceImpl
 
 /**
  * According to spec, when constructing a URL:

--- a/src/EventSource.ts
+++ b/src/EventSource.ts
@@ -91,13 +91,13 @@ export interface EventSource extends EventTarget {
   readonly withCredentials: boolean
 
   /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/EventSource/error_event) */
-  onerror: ((ev: ErrorEvent) => unknown) | null
+  onerror: ((this: EventSource, ev: ErrorEvent) => unknown) | null
 
   /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/EventSource/message_event) */
-  onmessage: ((ev: MessageEvent) => unknown) | null
+  onmessage: ((this: EventSource, ev: MessageEvent) => unknown) | null
 
   /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/EventSource/open_event) */
-  onopen: ((ev: Event) => unknown) | null
+  onopen: ((this: EventSource, ev: Event) => unknown) | null
 
   addEventListener<K extends keyof EventSourceEventMap>(
     type: K,
@@ -201,10 +201,10 @@ class EventSourceImpl extends EventTarget implements EventSource {
     return this.#withCredentials
   }
 
-  public get onerror(): ((ev: ErrorEvent) => unknown) | null {
+  public get onerror(): ((this: EventSource, ev: ErrorEvent) => unknown) | null {
     return this.#onError
   }
-  public set onerror(value: ((ev: ErrorEvent) => unknown) | null) {
+  public set onerror(value: ((this: EventSource, ev: ErrorEvent) => unknown) | null) {
     if (this.#onError) {
       this.removeEventListener('error', this.#onError)
     }
@@ -214,10 +214,10 @@ class EventSourceImpl extends EventTarget implements EventSource {
     }
   }
 
-  public get onmessage(): ((ev: MessageEvent) => unknown) | null {
+  public get onmessage(): ((this: EventSource, ev: MessageEvent) => unknown) | null {
     return this.#onMessage
   }
-  public set onmessage(value: ((ev: MessageEvent) => unknown) | null) {
+  public set onmessage(value: ((this: EventSource, ev: MessageEvent) => unknown) | null) {
     if (this.#onMessage) {
       this.removeEventListener('message', this.#onMessage)
     }
@@ -227,10 +227,10 @@ class EventSourceImpl extends EventTarget implements EventSource {
     }
   }
 
-  public get onopen(): ((ev: Event) => unknown) | null {
+  public get onopen(): ((this: EventSource, ev: Event) => unknown) | null {
     return this.#onOpen
   }
-  public set onopen(value: ((ev: Event) => unknown) | null) {
+  public set onopen(value: ((this: EventSource, ev: Event) => unknown) | null) {
     if (this.#onOpen) {
       this.removeEventListener('open', this.#onOpen)
     }
@@ -411,7 +411,7 @@ class EventSourceImpl extends EventTarget implements EventSource {
    *
    * @internal
    */
-  #onError: ((ev: ErrorEvent) => unknown) | null = null
+  #onError: ((this: EventSource, ev: ErrorEvent) => unknown) | null = null
 
   /**
    * Holds the current message handler, attached through `onmessage` property directly.
@@ -419,7 +419,7 @@ class EventSourceImpl extends EventTarget implements EventSource {
    *
    * @internal
    */
-  #onMessage: ((ev: MessageEvent) => unknown) | null = null
+  #onMessage: ((this: EventSource, ev: MessageEvent) => unknown) | null = null
 
   /**
    * Holds the current open handler, attached through `onopen` property directly.
@@ -427,7 +427,7 @@ class EventSourceImpl extends EventTarget implements EventSource {
    *
    * @internal
    */
-  #onOpen: ((ev: Event) => unknown) | null = null
+  #onOpen: ((this: EventSource, ev: Event) => unknown) | null = null
 
   /**
    * Connect to the given URL and start receiving events

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,3 @@
 export {ErrorEvent} from './errors.ts'
-export {EventSource} from './EventSource.ts'
+export {EventSource, type EventSourceConstructor} from './EventSource.ts'
 export type * from './types.ts'

--- a/src/types.ts
+++ b/src/types.ts
@@ -43,16 +43,29 @@ export interface EventSourceFetchInit {
 }
 
 /**
+ * A chunk read off a response body.
+ *
+ * Chunks are handed to a `TextDecoder`, which only accepts buffers, so this is what a reader has
+ * to yield to be usable. The union is spelled out because the node (`TypedArray | DataView`) and
+ * DOM (`ArrayBufferView`) typings describe "any buffer view" differently, and these three members
+ * are accepted by both.
+ */
+type BodyChunk = Uint8Array | DataView | ArrayBuffer
+
+/**
  * Stripped down version of `ReadableStreamDefaultReader`, only defining the parts we care about.
  *
- * Note that the `done: true` result allows a `value` of any type: TypeScript 5.9's DOM lib types
- * `ReadableStreamDefaultReader.read()`'s done-result as `{done: true, value: T | undefined}`, so
- * requiring `value` to be absent/undefined would reject standard readers.
+ * Note that the `done: true` result allows `value` to be missing _or_ explicitly `undefined`:
+ * TypeScript 5.9's DOM lib types `ReadableStreamDefaultReader.read()`'s done-result as
+ * `{done: true, value: T | undefined}`, so under `exactOptionalPropertyTypes` an optional
+ * property alone would reject standard readers.
  *
  * @public
  */
 export interface ReaderLike {
-  read(): Promise<{done: false; value: unknown} | {done: true; value?: unknown}>
+  read(): Promise<
+    {done: false; value: BodyChunk} | {done: true; value?: BodyChunk | undefined}
+  >
   cancel(): Promise<void>
 }
 

--- a/test/tests.ts
+++ b/test/tests.ts
@@ -724,6 +724,34 @@ export function registerTests(options: {
     await deferClose(es)
   })
 
+  test('throws on `fetch()` yielding chunks that are not buffers', async () => {
+    const url = `${baseUrl}:${port}/`
+
+    // @ts-expect-error `value` should be a buffer, which is all a `TextDecoder` accepts
+    const faultyFetch: FetchLike = async () => ({
+      body: {
+        getReader: () => ({
+          read: async () => ({done: false, value: 'not a buffer'}),
+          cancel: async () => {},
+        }),
+      },
+      redirected: false,
+      status: 200,
+      headers: new Headers({'content-type': 'text/event-stream'}),
+      url,
+    })
+
+    const onError = getCallCounter({name: 'onError'})
+    const es = new OurEventSource(url, {fetch: faultyFetch})
+
+    es.addEventListener('error', onError)
+    await onError.waitForCallCount(1)
+
+    // The message comes from the runtime's `TextDecoder`, and differs between environments
+    expect(onError.lastCall.lastArg).toMatchObject({type: 'error'})
+    await deferClose(es)
+  })
+
   test('[NON-SPEC] message event contains extended properties (failed connection)', async () => {
     const onError = getCallCounter({name: 'onError'})
     const es = new OurEventSource(`${baseUrl}:9999/should-not-connect`, {fetch})

--- a/test/type-compatible.ts
+++ b/test/type-compatible.ts
@@ -28,9 +28,10 @@ function testESImpl(EvtSource: EventSourceConstructor) {
   /* eslint-disable no-console */
 
   // Message.
-  // Note that unlike `lib.dom.d.ts`, we do not declare a `this` type for the `on*` handler
-  // properties, so functions relying on `this` have to annotate it explicitly.
-  es.onmessage = function (this: EventSourcePolyfill, evt) {
+  // Both the `on*` properties and `addEventListener` declare the `this` type, so it is inferred
+  // for inline handlers. Standalone function declarations still have to annotate it, since
+  // TypeScript only contextually types `this` for function expressions.
+  es.onmessage = function (evt) {
     console.log(typeof evt.data === 'string')
     console.log(evt.defaultPrevented === false)
     console.log(evt.type === 'message')
@@ -47,13 +48,12 @@ function testESImpl(EvtSource: EventSourceConstructor) {
   es.addEventListener('message', onMessage)
   es.removeEventListener('message', onMessage)
 
-  // `addEventListener` _does_ declare the `this` type, so it is inferred for inline listeners
   es.addEventListener('message', function (evt) {
     console.log(this.url, evt.data)
   })
 
   // Error
-  es.onerror = function (this: EventSourcePolyfill, event) {
+  es.onerror = function (event) {
     console.log(event.defaultPrevented === false)
     console.log(event.type === 'error')
     console.log(this === es)
@@ -74,7 +74,7 @@ function testESImpl(EvtSource: EventSourceConstructor) {
   })
 
   // Open
-  es.onopen = function (this: EventSourcePolyfill, event) {
+  es.onopen = function (event) {
     console.log(event.defaultPrevented === false)
     console.log(event.type === 'open')
     console.log(this === es)

--- a/test/type-compatible.ts
+++ b/test/type-compatible.ts
@@ -1,26 +1,43 @@
 /**
  * Ensures that our EventSource polyfill is as type-compatible as possible with the
  * WhatWG EventSource implementation/types (defined in TypeScript's `lib.dom.d.ts`).
+ *
+ * Checked against the built declarations in `dist`, since those - not the source - are what
+ * consumers of the published package see. Run with `npm run test:types`; the file is only
+ * ever type checked, never executed.
  */
-import {EventSource as EventSourcePolyfill} from '../src/EventSource'
-import type {EventSourceInit, FetchLike} from '../src/types'
+import {
+  type EventSourceConstructor,
+  EventSource as EventSourcePolyfill,
+  type EventSourceInit,
+  type FetchLike,
+} from '../dist/index.js'
 
-function testESImpl(EvtSource: typeof globalThis.EventSource | typeof EventSourcePolyfill) {
+/** A native `EventSource`, as typed by TypeScript's `lib.dom.d.ts` */
+declare const native: globalThis.EventSource
+
+/**
+ * Anything that satisfies our public constructor type must be usable through the full API,
+ * including the native `EventSource` - which is passed in below.
+ */
+function testESImpl(EvtSource: EventSourceConstructor) {
   const es = new EvtSource('https://foo.bar', {
     withCredentials: true,
   }) satisfies globalThis.EventSource
 
   /* eslint-disable no-console */
 
-  // Message
-  es.onmessage = function (evt) {
+  // Message.
+  // Note that unlike `lib.dom.d.ts`, we do not declare a `this` type for the `on*` handler
+  // properties, so functions relying on `this` have to annotate it explicitly.
+  es.onmessage = function (this: EventSourcePolyfill, evt) {
     console.log(typeof evt.data === 'string')
     console.log(evt.defaultPrevented === false)
     console.log(evt.type === 'message')
     console.log(this === es)
   }
 
-  function onMessage(evt: MessageEvent) {
+  function onMessage(this: EventSourcePolyfill, evt: MessageEvent) {
     console.log(typeof evt.data === 'string')
     console.log(evt.defaultPrevented === false)
     console.log(evt.type === 'message')
@@ -30,14 +47,19 @@ function testESImpl(EvtSource: typeof globalThis.EventSource | typeof EventSourc
   es.addEventListener('message', onMessage)
   es.removeEventListener('message', onMessage)
 
+  // `addEventListener` _does_ declare the `this` type, so it is inferred for inline listeners
+  es.addEventListener('message', function (evt) {
+    console.log(this.url, evt.data)
+  })
+
   // Error
-  es.onerror = function (event) {
+  es.onerror = function (this: EventSourcePolyfill, event) {
     console.log(event.defaultPrevented === false)
     console.log(event.type === 'error')
     console.log(this === es)
   }
 
-  function onError(event: Event) {
+  function onError(this: EventSourcePolyfill, event: Event) {
     console.log(event.defaultPrevented === false)
     console.log(event.type === 'error')
     console.log(this === es)
@@ -46,14 +68,19 @@ function testESImpl(EvtSource: typeof globalThis.EventSource | typeof EventSourc
   es.addEventListener('error', onError)
   es.removeEventListener('error', onError)
 
+  // Our `error` events carry non-spec extras, which must survive on the listener signature
+  es.addEventListener('error', (event) => {
+    console.log(event.code === 500, event.message === 'Internal Server Error')
+  })
+
   // Open
-  es.onopen = function (event) {
+  es.onopen = function (this: EventSourcePolyfill, event) {
     console.log(event.defaultPrevented === false)
     console.log(event.type === 'open')
     console.log(this === es)
   }
 
-  function onOpen(event: Event) {
+  function onOpen(this: EventSourcePolyfill, event: Event) {
     console.log(event.defaultPrevented === false)
     console.log(event.type === 'open')
     console.log(this === es)
@@ -77,6 +104,61 @@ function testESImpl(EvtSource: typeof globalThis.EventSource | typeof EventSourc
 
 testESImpl(EventSourcePolyfill)
 testESImpl(globalThis.EventSource)
+
+/**
+ * The exported `EventSource` type must be structural, eg free of the `#private` brand that
+ * TypeScript emits into declaration files for classes holding hard-private (`#`) fields.
+ * That brand makes the type nominal, which prevents consumers from passing the native
+ * `EventSource`, a mock, or another implementation where our type is expected.
+ */
+function testStructuralCompat() {
+  // A native `EventSource` must be assignable to our exported type
+  const nativeAsPolyfill: EventSourcePolyfill = native
+
+  // …as must a hand-rolled stub, for consumers mocking the client in their tests
+  const mock: EventSourcePolyfill = {
+    CONNECTING: 0,
+    OPEN: 1,
+    CLOSED: 2,
+    readyState: 1,
+    url: 'https://foo.bar',
+    withCredentials: false,
+    onerror: null,
+    onmessage: null,
+    onopen: null,
+    addEventListener: () => {},
+    removeEventListener: () => {},
+    dispatchEvent: () => true,
+    close: () => {},
+  }
+
+  // The constructor must be interchangeable with the native one, in both directions
+  const nativeCtor: EventSourceConstructor = globalThis.EventSource
+  const polyfillCtor: typeof globalThis.EventSource = EventSourcePolyfill
+
+  return [nativeAsPolyfill, mock, nativeCtor, polyfillCtor]
+}
+
+testStructuralCompat()
+
+/**
+ * Consumers must still be able to subclass the exported `EventSource`, and instances of such
+ * subclasses must remain assignable to both our type and the native one.
+ */
+function testSubclassing() {
+  class WrappedEventSource extends EventSourcePolyfill {
+    public reconnects = 0
+
+    override close(): void {
+      super.close()
+    }
+  }
+
+  const wrapped = new WrappedEventSource('https://foo.bar', {withCredentials: true})
+  return [wrapped satisfies EventSourcePolyfill, wrapped satisfies globalThis.EventSource]
+}
+
+testSubclassing()
 
 /**
  * `FetchLike` must accept standard fetch implementations: TypeScript 5.9's DOM lib types

--- a/tsconfig.types.json
+++ b/tsconfig.types.json
@@ -1,6 +1,6 @@
 {
   "extends": "./tsconfig.settings",
-  "include": ["./test/type-compatible.ts"],
+  "include": ["./src", "./test/type-compatible.ts"],
   "compilerOptions": {
     "noEmit": true,
 

--- a/tsconfig.types.json
+++ b/tsconfig.types.json
@@ -1,0 +1,12 @@
+{
+  "extends": "./tsconfig.settings",
+  "include": ["./test/type-compatible.ts"],
+  "compilerOptions": {
+    "noEmit": true,
+
+    // The type compatibility checks compare our types against the WhatWG `EventSource`,
+    // defined in TypeScript's `dom` library - unlike the library build, which must not
+    // depend on DOM typings being present.
+    "lib": ["ES2023", "DOM"]
+  }
+}


### PR DESCRIPTION
Three related improvements to the public type surface, one per commit.

### Export `EventSource` as a structural interface

`EventSource` was exported as a class holding hard-private (`#`) fields, so TypeScript emitted a `#private` brand into the declaration file and the exported type became nominal. Consumers writing `function connect(es: EventSource)` against this package could not pass the native `EventSource`, a mock, or any other implementation, even on an exact shape match:

```
error TS2741: Property '#private' is missing in type 'EventSource'
              but required in type 'eventsource/dist/EventSource'.EventSource
```

The implementation class is now internal, and `EventSource` is exported as an `interface` plus a const holding the constructor. A new `EventSourceConstructor` type is exported for code that takes an implementation to construct, which is the case the "Feature checking" section of the README describes.

Nothing changes at runtime. The class keeps its private fields, and its `name` is restored with `Object.defineProperty` so neither `EventSource.name` nor inspected instances (`console.log(eventSource)`) leak the internal name. Cost is 19 bytes gzipped, from the name shim and the const alias.

### Declare `this` for the on-handler properties

`addEventListener()` already declared that listeners are invoked with the instance as `this`, but `onerror`, `onmessage` and `onopen` did not, leaving `this` an implicit `any` there. They now match `addEventListener()` and `lib.dom.d.ts`:

```ts
eventSource.onmessage = function (event) {
  console.log(this.url, event.data) // `this` is now typed
}
```

Handlers declaring an incompatible `this`, eg an unbound class method typed `this: MyClass`, will now be rejected where they were previously accepted. Arrow functions and handlers that ignore `this` are unaffected.

### Type response body chunks as buffers

`ReaderLike` typed chunks read off the response body as `unknown`, but they go straight into a `TextDecoder`, which only accepts buffers and throws on anything else. The type promised more than the code could take, and it hid a type error in the client itself: the node typings resolve the chunk to `any`, so it slipped through, while under the `dom` library it is `{}` and an error.

Chunks are now typed `Uint8Array | DataView | ArrayBuffer`, which is what both the node (`TypedArray | DataView`) and DOM (`ArrayBufferView`) typings accept, and which every `fetch()` implementation yields. Fixing it in the type rather than narrowing at the call site keeps it free: the emitted JavaScript is byte-for-byte unchanged.

If you pass a custom `fetch()` returning a hand-rolled body whose reader yields a wider chunk type, eg `unknown`, it will no longer be assignable. Returning a real `Response` is unaffected.

### Worth knowing while reviewing

- `test/type-compatible.ts` was not type checked by anything: nothing imports it, and `tsc` only included `./src`. It had accumulated errors, including `addEventListener` calls that could not have compiled because `testESImpl` took a union of two constructor types, which collapses the overloads. It now takes an `EventSourceConstructor`, so passing `globalThis.EventSource` is itself the compatibility assertion.
- It is pointed at the built declarations in `dist` rather than `src`, since `publishConfig.exports` drops the `source` condition and `dist` is what consumers actually resolve.
- It runs through `npm run test:types` and a new CI job. `posttest` never fires in CI, since the workflow calls `test:node` and friends directly rather than `npm test`, so wiring the check only into `lint` would have left it not running.
- With the chunk types fixed, `./src` joins that same check, so the client is verified against both lib configurations from now on.
- `package.json` and `test/tests.ts` are reported as unformatted by `oxfmt`, but both were already unformatted on `main`, so I left them alone rather than mixing unrelated churn into this diff.