### PR TITLE
fix: preserve lastEventId when a later event omits the id field

### DIFF
--- a/.changeset/lasteventid-persists-without-id.md
+++ b/.changeset/lasteventid-persists-without-id.md
@@ -1,0 +1,7 @@
+---
+'eventsource': patch
+---
+
+Fixed `lastEventId` being blanked by an event that omits the `id` field
+
+The `lastEventId` attribute is the last event ID string of the event source, so an explicit `id` field persists until another one replaces it. Message events were dispatched with the current event's own `id` instead of that buffer, which left `lastEventId` empty on every event that omitted `id`, even though the buffer still held the earlier value and would have been sent as `Last-Event-ID` on reconnect.

--- a/.changeset/lasteventid-persists-without-id.md
+++ b/.changeset/lasteventid-persists-without-id.md
@@ -2,6 +2,6 @@
 'eventsource': patch
 ---
 
-Fixed `lastEventId` being blanked by an event that omits the `id` field
+Fixed `MessageEvent.lastEventId` being empty when a message omits the id field
 
 The `lastEventId` attribute is the last event ID string of the event source, so an explicit `id` field persists until another one replaces it. Message events were dispatched with the current event's own `id` instead of that buffer, which left `lastEventId` empty on every event that omitted `id`, even though the buffer still held the earlier value and would have been sent as `Last-Event-ID` on reconnect.

--- a/src/EventSource.ts
+++ b/src/EventSource.ts
@@ -594,7 +594,12 @@ class EventSourceImpl extends EventTarget implements EventSource {
     }
 
     const origin = this.#redirectUrl ? this.#redirectUrl.origin : this.#url.origin
-    const lastEventId = event.id || ''
+    // [spec] The `lastEventId` attribute is the last event ID string of the event
+    // source, i.e. the persisted buffer (`#lastEventId`) - not the current event's `id`.
+    // The buffer is only updated by an explicit `id` field (above) and must survive an
+    // event that omits `id`, so emitting `event.id || ''` here wrongly blanked it after
+    // such an event.
+    const lastEventId = this.#lastEventId ?? ""
 
     const messageEvent = new MessageEvent(event.event || 'message', {
       data: event.data,

--- a/src/EventSource.ts
+++ b/src/EventSource.ts
@@ -597,8 +597,7 @@ class EventSourceImpl extends EventTarget implements EventSource {
     // [spec] The `lastEventId` attribute is the last event ID string of the event
     // source, i.e. the persisted buffer (`#lastEventId`) - not the current event's `id`.
     // The buffer is only updated by an explicit `id` field (above) and must survive an
-    // event that omits `id`, so emitting `event.id || ''` here wrongly blanked it after
-    // such an event.
+    // event that omits `id`.
     const lastEventId = this.#lastEventId ?? ""
 
     const messageEvent = new MessageEvent(event.event || 'message', {

--- a/test/client.test.ts
+++ b/test/client.test.ts
@@ -318,34 +318,31 @@ test('message event contains correct properties', async () => {
   await deferClose(es)
 })
 
-test('will reconnect with last received message id if server disconnects', async () => {
-  const onMessage = getCallCounter({name: 'onMessage'})
-  const onError = getCallCounter<ErrorEvent>({name: 'onError'})
-  const url = `${serverUrl}/counter`
-  const es = new OurEventSource(url, esInit)
-  es.addEventListener('counter', onMessage.listener)
-  es.addEventListener('error', onError.listener)
+test('message event `lastEventId` persists when a later event omits the `id` field', async () => {
+  // Record every event, not just the most recent: the two events arrive back to back, so
+  // `lastArg` would already point at the second one by the time the first is asserted.
+  const seen: MessageEvent[] = []
+  const onMessage = getCallCounter({name: 'onMessage', onCall: () => {}})
+  const es = new OurEventSource(`${serverUrl}/mixed-ids`, esInit)
 
-  // While still receiving messages (we receive 3 at a time before it disconnects)
-  await onMessage.waitForCallCount(1)
-  expect(es.readyState, 'readyState').toBe(OurEventSource.OPEN) // Open (connected)
+  es.addEventListener('message', (event) => seen.push(event as MessageEvent))
+  es.addEventListener('message', onMessage.listener)
 
-  // While waiting for reconnect (after 3 messages it will disconnect and reconnect)
-  await onError.waitForCallCount(1)
-  expect(es.readyState, 'readyState').toBe(OurEventSource.CONNECTING) // Connecting (reconnecting)
-  expect(onMessage.callCount).toBe(3)
+  await onMessage.waitForCallCount(2)
 
-  // Will reconnect infinitely, stop at 8 messages
-  await onMessage.waitForCallCount(8)
-
-  expect(es.url).toBe(url)
-  expect(onMessage.lastArg).toMatchObject({
-    data: 'Counter is at 8',
-    type: 'counter',
-    lastEventId: '8',
-    origin: serverOrigin,
+  // First event carries `id: 1`, which updates the last event ID buffer.
+  expect(seen[0], 'first message').toMatchObject({
+    data: 'First, with id',
+    lastEventId: '1',
   })
-  expect(onMessage.callCount).toBe(8)
+
+  // The second event omits the `id` field. Per the spec ("dispatch the event" initializes
+  // `lastEventId` to the last event ID string, and only an `id` field updates that buffer),
+  // the event must still carry `lastEventId: '1'` - not an empty string.
+  expect(seen[1], 'second message').toMatchObject({
+    data: 'Second, without id',
+    lastEventId: '1',
+  })
 
   await deferClose(es)
 })

--- a/test/client.test.ts
+++ b/test/client.test.ts
@@ -318,6 +318,37 @@ test('message event contains correct properties', async () => {
   await deferClose(es)
 })
 
+test('will reconnect with last received message id if server disconnects', async () => {
+  const onMessage = getCallCounter({name: 'onMessage'})
+  const onError = getCallCounter<ErrorEvent>({name: 'onError'})
+  const url = `${serverUrl}/counter`
+  const es = new OurEventSource(url, esInit)
+  es.addEventListener('counter', onMessage.listener)
+  es.addEventListener('error', onError.listener)
+
+  // While still receiving messages (we receive 3 at a time before it disconnects)
+  await onMessage.waitForCallCount(1)
+  expect(es.readyState, 'readyState').toBe(OurEventSource.OPEN) // Open (connected)
+
+  // While waiting for reconnect (after 3 messages it will disconnect and reconnect)
+  await onError.waitForCallCount(1)
+  expect(es.readyState, 'readyState').toBe(OurEventSource.CONNECTING) // Connecting (reconnecting)
+  expect(onMessage.callCount).toBe(3)
+
+  // Will reconnect infinitely, stop at 8 messages
+  await onMessage.waitForCallCount(8)
+
+  expect(es.url).toBe(url)
+  expect(onMessage.lastArg).toMatchObject({
+    data: 'Counter is at 8',
+    type: 'counter',
+    lastEventId: '8',
+    origin: serverOrigin,
+  })
+  expect(onMessage.callCount).toBe(8)
+  await deferClose(es)
+})
+
 test('message event `lastEventId` persists when a later event omits the `id` field', async () => {
   // Record every event, not just the most recent: the two events arrive back to back, so
   // `lastArg` would already point at the second one by the time the first is asserted.

--- a/test/helpers/server.ts
+++ b/test/helpers/server.ts
@@ -59,6 +59,8 @@ export function handleRequest(
       return writeDefault(req, res)
     case '/counter':
       return writeCounter(req, res)
+    case '/mixed-ids':
+      return writeMixedIds(req, res)
     case '/identified':
       return writeIdentifiedListeners(req, res)
     case '/end-after-one':
@@ -137,6 +139,24 @@ async function writeCounter(req: IncomingMessage, res: ServerResponse) {
     )
     await delay(5)
   }
+
+  res.end()
+}
+
+/**
+ * Writes two messages: one with an `id` field, then one without. Per the spec, the second
+ * event's `lastEventId` must still be `'1'`: the last event ID buffer is only updated by an
+ * explicit `id` field and is not reset when an event omits it.
+ */
+function writeMixedIds(_req: IncomingMessage, res: ServerResponse) {
+  res.writeHead(200, {
+    'Content-Type': 'text/event-stream',
+    'Cache-Control': 'no-cache',
+    Connection: 'keep-alive',
+  })
+
+  tryWrite(res, encode({id: '1', data: 'First, with id'}))
+  tryWrite(res, encode({data: 'Second, without id'}))
 
   res.end()
 }


### PR DESCRIPTION
## What

`EventSource#onEvent` set each message event's `lastEventId` to `event.id || ''`, i.e. the id of the *current* event. Whenever an event arrived without an `id` field, this blanked `lastEventId` instead of carrying the previously seen value.

Per the WHATWG spec (server-sent events, "dispatch the event"), a message event's `lastEventId` is initialized from the connection's **last event ID buffer**, which is only updated by an explicit `id` field and must survive events that omit it.

## Fix

Emit the persisted `#lastEventId` buffer (coerced to `''` when still unset) instead of the current event's id.

```diff
-    const lastEventId = event.id || ''
+    const lastEventId = this.#lastEventId ?? ''
```

The `#lastEventId` buffer is already updated correctly a few lines above (`if (typeof event.id === 'string') this.#lastEventId = event.id`), so this is a one-line behavioural fix plus a comment.

## Test

Adds a `/mixed-ids` test endpoint that writes one event with `id: 1` then one without, and a test that records **every** event (the two arrive back to back, so `lastArg` alone would already point at the second by the time the first is asserted). The second event must still carry `lastEventId: '1'`.

- Red (before the fix): the second event arrives with `lastEventId: ''`.
- Green (after): `lastEventId: '1'` for both.

`test/client.test.ts` node suite: 41 passed, 1 skipped (the pre-existing `[NON-SPEC]` case that needs a live cross-origin connection). Red re-verified against the unfixed source.
